### PR TITLE
Add agent instructions for Claude, Copilot and other tools

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,28 +1,22 @@
 # Copilot instructions — Abdeljalil Theme
 
 A classic (non-block) WordPress theme for an Arabic, right-to-left blog. Plain PHP templates and one
-stylesheet. There is no build step and no package manager — no `composer.json`, no `package.json`.
-Do not introduce a toolchain.
+stylesheet, no build step, no package manager.
 
-The full guide is [`AGENTS.md`](../AGENTS.md). The rules that matter most:
+The full guide is [`AGENTS.md`](../AGENTS.md): coding standards, verification steps, the
+version-bumping rule and the boundaries on what belongs in a theme. Read it. Repeated here are only
+the three things most often got wrong in this repo.
 
-- **Escape at output, with the matching function.** `esc_html()` for text, `esc_attr()` for
-  attributes, `esc_url()` for URLs, `wp_kses_post()` for markup. Hex colours get
-  `sanitize_hex_color()` — `esc_attr()` is not a CSS escaper.
-- **Wrap user-facing strings** in the `abdeljalil` text domain (`__()`, `_e()`, `esc_html__()`).
-- **RTL first.** Use CSS logical properties (`inset-inline-start`, `margin-block-end`), never
-  `left`/`right`. There is no `rtl.css`.
-- **WordPress PHP coding standards**, as the files already follow them: tabs, spaces inside
-  parentheses `function foo( $bar )`, Yoda conditions, long-form `array()`.
-- **Prefix new functions `abdeljalil_`** (see #20 — do not add to the existing prefix split).
-- **No plugin behaviour in the theme.** Anything that should survive a theme switch belongs in a
-  plugin.
-- **No remote assets.** Everything ships from the theme directory.
-- **Do not duplicate core.** WordPress already emits canonical URLs, robots directives, sitemaps and
-  the title tag.
+- **Escape at output, with the function that matches the context.** `esc_html()` for text,
+  `esc_attr()` for attributes, `esc_url()` for URLs. `esc_attr()` is not a CSS escaper; hex colours
+  get `sanitize_hex_color()`.
+- **Use CSS logical properties** such as `inset-inline-start` and `margin-block-end`, not
+  `left`/`right`. There is no `rtl.css`; `style.css` is RTL-first.
+- **Every user-facing string goes through the `abdeljalil` text domain**, via `__()`, `_e()` or
+  `esc_html__()`.
 
-There is no test suite. Verify manually across home, single post, archive, search, page and 404,
-with `WP_DEBUG` on, and view source rather than trusting that it looks right.
-
-The version lives in both `style.css` (`Version:`) and the `wp_enqueue_style()` call in
-`functions.php`. Bump both together or browsers serve a stale stylesheet.
+<!--
+Why this file exists alongside AGENTS.md: Copilot Chat does not read AGENTS.md in JetBrains, Visual
+Studio, Eclipse or Xcode, and @ file references expand only in Copilot CLI. This path is the one
+instruction file every Copilot surface reads. Keep it short and let AGENTS.md carry the detail.
+-->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# Copilot instructions — Abdeljalil Theme
+
+A classic (non-block) WordPress theme for an Arabic, right-to-left blog. Plain PHP templates and one
+stylesheet. There is no build step and no package manager — no `composer.json`, no `package.json`.
+Do not introduce a toolchain.
+
+The full guide is [`AGENTS.md`](../AGENTS.md). The rules that matter most:
+
+- **Escape at output, with the matching function.** `esc_html()` for text, `esc_attr()` for
+  attributes, `esc_url()` for URLs, `wp_kses_post()` for markup. Hex colours get
+  `sanitize_hex_color()` — `esc_attr()` is not a CSS escaper.
+- **Wrap user-facing strings** in the `abdeljalil` text domain (`__()`, `_e()`, `esc_html__()`).
+- **RTL first.** Use CSS logical properties (`inset-inline-start`, `margin-block-end`), never
+  `left`/`right`. There is no `rtl.css`.
+- **WordPress PHP coding standards**, as the files already follow them: tabs, spaces inside
+  parentheses `function foo( $bar )`, Yoda conditions, long-form `array()`.
+- **Prefix new functions `abdeljalil_`** (see #20 — do not add to the existing prefix split).
+- **No plugin behaviour in the theme.** Anything that should survive a theme switch belongs in a
+  plugin.
+- **No remote assets.** Everything ships from the theme directory.
+- **Do not duplicate core.** WordPress already emits canonical URLs, robots directives, sitemaps and
+  the title tag.
+
+There is no test suite. Verify manually across home, single post, archive, search, page and 404,
+with `WP_DEBUG` on, and view source rather than trusting that it looks right.
+
+The version lives in both `style.css` (`Version:`) and the `wp_enqueue_style()` call in
+`functions.php`. Bump both together or browsers serve a stale stylesheet.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# Abdeljalil Theme — agent guide
+
+A classic (non-block) WordPress theme for an Arabic, right-to-left blog. Originally by Abdeljalil in
+2016, modernized and maintained by [Al-Mothafar Al-Hasan](https://almothafar.com).
+
+Plain PHP templates and one stylesheet. **No build step, no dependencies, no package manager** — no
+`composer.json`, no `package.json`, no `node_modules`. What is in the repo is what ships. Do not
+introduce a toolchain to solve a problem that a few lines of PHP or CSS solve.
+
+## Layout
+
+| Path | What it is |
+|---|---|
+| `functions.php` | Everything: theme setup, Customizer, enqueues, SEO output, comment callback |
+| `header.php` `footer.php` `sidebar.php` | Chrome, wrapped around every page |
+| `index.php` `archive.php` `search.php` `single.php` `page.php` `404.php` | The template hierarchy |
+| `template-parts/` | Shared fragments pulled in with `get_template_part()` |
+| `comments.php` `searchform.php` | Template overrides for core output |
+| `style.css` | The whole design, plus the theme header WordPress reads |
+| `fonts/` `images/` | Noto Kufi Arabic, and the header images offered in the Customizer |
+
+## Non-negotiables
+
+**Escape at output, with the function that matches the context.** `esc_html()` for text,
+`esc_attr()` for attributes, `esc_url()` for URLs, `wp_kses_post()` for markup that may contain
+allowed HTML. Escape at the point of echo, not earlier — an escaped value passed around is a value
+nobody can tell is safe. `esc_attr()` is not a CSS escaper; hex colours get `sanitize_hex_color()`.
+
+**Every user-facing string goes through the `abdeljalil` text domain** — `__()`, `_e()`, `esc_html__()`,
+`_n()`. There is a lot of hard-coded Arabic in the templates that predates this rule; do not add
+more, and wrap what you touch.
+
+**RTL is the default, not an afterthought.** Use CSS logical properties — `inset-inline-start`,
+`margin-block-end`, `padding-inline` — never `left`/`right`/`margin-left`. The theme has no
+`rtl.css` and does not want one; `style.css` is RTL-first.
+
+**Follow the WordPress PHP coding standards, as the file already does.** Tabs for indentation.
+Spaces inside parentheses: `function foo( $bar )`. Yoda conditions: `if ( '' === $value )`. Array
+syntax is long-form `array()` throughout — match it rather than mixing in `[]`.
+
+**Prefix new functions `abdeljalil_`.** The file currently mixes `abdeljalil_` and `almothafar_`
+(and `ALMOTHAFAR_` for constants), which is being tracked in #20. Do not add to the split.
+
+**Do not put plugin behaviour in the theme.** Anything that should survive a theme switch — disabling
+XML-RPC, analytics, redirects, custom post types — belongs in a plugin. A user who switches themes
+should not silently lose or regain site behaviour.
+
+**No remote assets.** No CDN stylesheets, scripts or fonts. Every asset is served from the theme
+directory. Loading from a third party discloses every visitor's IP to that host and cannot be
+audited. (One CDN dependency remains and is being removed in #11.)
+
+**Do not reimplement what core already does.** Before adding output to `wp_head`, check whether
+WordPress emits it already — canonical URLs, robots directives, sitemaps, feed links and the title
+tag are all core's job. Duplicating them is worse than omitting them.
+
+## Verifying a change
+
+There is no test suite and no CI. Verification is manual, so say in the PR what you actually checked.
+
+- **Front end:** home, a single post with comments, a category archive, a search result (including
+  one with no results), a page, and a 404.
+- **PHP notices:** run with `WP_DEBUG` on and confirm the change adds none.
+- **Markup:** the theme has a history of duplicate-attribute and unbalanced-`div` bugs (#5, #6) —
+  view source rather than trusting that it looks right.
+- **RTL:** check the change at a mobile width too; the layout collapses to one column at 600px.
+- **Editor:** if the change touches enqueues, `theme.json` or editor styles, open the post editor.
+
+## Version bumping
+
+The version lives in **two** places and they must move together:
+
+- `style.css` — the `Version:` line in the theme header
+- `functions.php` — the version argument passed to `wp_enqueue_style( 'abdeljalil-style', ... )`
+
+If they disagree, browsers serve a stale stylesheet after an update. Bump both in the same commit.
+
+`Tested up to:` in `style.css` should track the WordPress version the change was actually verified
+against — do not raise it speculatively.
+
+## Commits and pull requests
+
+Short imperative subject, no trailing period. Explain *why* in the body when the reason is not
+obvious from the diff. One logical change per PR.
+
+Reference the issue the work belongs to (`Closes #12`). The tracker is organised into milestones
+M1–M5, ordered by payoff — start at the lowest open milestone unless there is a reason not to.
+
+Some issues deliberately overlap: #5, #14 and #16 all touch the same four listing templates, and #11
+and #14 touch the same icon markup. Each of those issues carries a note saying which to land first.
+Read it before starting, so the same lines are not rewritten twice.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,88 +3,76 @@
 A classic (non-block) WordPress theme for an Arabic, right-to-left blog. Originally by Abdeljalil in
 2016, modernized and maintained by [Al-Mothafar Al-Hasan](https://almothafar.com).
 
-Plain PHP templates and one stylesheet. **No build step, no dependencies, no package manager** — no
-`composer.json`, no `package.json`, no `node_modules`. What is in the repo is what ships. Do not
-introduce a toolchain to solve a problem that a few lines of PHP or CSS solve.
+Plain PHP templates and one stylesheet, served exactly as committed. There is no build step and no
+package manager today. If a task genuinely needs one, say so in the PR rather than adding it quietly,
+and commit the output rather than building on demand.
 
-## Layout
+`functions.php` is the one thing worth knowing about the layout: roughly 800 lines holding theme
+setup, the Customizer, enqueues, all SEO output and the comment callback. It is divided into sections
+by `/****...****/` banner comments. Put new code in the section it belongs to, and add a banner if it
+needs a new one.
 
-| Path | What it is |
-|---|---|
-| `functions.php` | Everything: theme setup, Customizer, enqueues, SEO output, comment callback |
-| `header.php` `footer.php` `sidebar.php` | Chrome, wrapped around every page |
-| `index.php` `archive.php` `search.php` `single.php` `page.php` `404.php` | The template hierarchy |
-| `template-parts/` | Shared fragments pulled in with `get_template_part()` |
-| `comments.php` `searchform.php` | Template overrides for core output |
-| `style.css` | The whole design, plus the theme header WordPress reads |
-| `fonts/` `images/` | Noto Kufi Arabic, and the header images offered in the Customizer |
-
-## Non-negotiables
+## Rules
 
 **Escape at output, with the function that matches the context.** `esc_html()` for text,
 `esc_attr()` for attributes, `esc_url()` for URLs, `wp_kses_post()` for markup that may contain
-allowed HTML. Escape at the point of echo, not earlier — an escaped value passed around is a value
-nobody can tell is safe. `esc_attr()` is not a CSS escaper; hex colours get `sanitize_hex_color()`.
+allowed HTML. Escape at the point of echo, not earlier: an escaped value passed around is a value
+nobody can tell is safe. `esc_attr()` is not a CSS escaper, and hex colours get
+`sanitize_hex_color()`.
 
-**Every user-facing string goes through the `abdeljalil` text domain** — `__()`, `_e()`, `esc_html__()`,
-`_n()`. There is a lot of hard-coded Arabic in the templates that predates this rule; do not add
-more, and wrap what you touch.
+**Every user-facing string goes through the `abdeljalil` text domain**, via `__()`, `_e()`,
+`esc_html__()` or `_n()`. Plenty of hard-coded Arabic predates this rule. Do not add more, and wrap
+what you touch.
 
-**RTL is the default, not an afterthought.** Use CSS logical properties — `inset-inline-start`,
-`margin-block-end`, `padding-inline` — never `left`/`right`/`margin-left`. The theme has no
-`rtl.css` and does not want one; `style.css` is RTL-first.
+**Use CSS logical properties** such as `inset-inline-start`, `margin-block-end` and `padding-inline`,
+not `left`/`right`/`margin-left`. There is no `rtl.css`; `style.css` is RTL-first and stays that way.
 
-**Follow the WordPress PHP coding standards, as the file already does.** Tabs for indentation.
-Spaces inside parentheses: `function foo( $bar )`. Yoda conditions: `if ( '' === $value )`. Array
-syntax is long-form `array()` throughout — match it rather than mixing in `[]`.
+**Follow the WordPress PHP coding standards, as the files already do.** Tabs for indentation. Spaces
+inside parentheses: `function foo( $bar )`. Yoda conditions: `if ( '' === $value )`. Long-form
+`array()`, not `[]`.
 
-**Prefix new functions `abdeljalil_`.** The file currently mixes `abdeljalil_` and `almothafar_`
-(and `ALMOTHAFAR_` for constants), which is being tracked in #20. Do not add to the split.
+**Prefix new functions `abdeljalil_`.** The file also holds `almothafar_` functions and
+`ALMOTHAFAR_` constants from a later pass. Do not add to the split.
 
-**Do not put plugin behaviour in the theme.** Anything that should survive a theme switch — disabling
-XML-RPC, analytics, redirects, custom post types — belongs in a plugin. A user who switches themes
-should not silently lose or regain site behaviour.
+**Do not put plugin behaviour in the theme.** Anything that should survive a theme switch, such as
+disabling XML-RPC, analytics, redirects or custom post types, belongs in a plugin. A user who
+switches themes should not silently lose or regain site behaviour.
 
-**No remote assets.** No CDN stylesheets, scripts or fonts. Every asset is served from the theme
+**No remote assets.** No CDN stylesheets, scripts or fonts. Everything ships from the theme
 directory. Loading from a third party discloses every visitor's IP to that host and cannot be
-audited. (One CDN dependency remains and is being removed in #11.)
+audited.
 
 **Do not reimplement what core already does.** Before adding output to `wp_head`, check whether
-WordPress emits it already — canonical URLs, robots directives, sitemaps, feed links and the title
-tag are all core's job. Duplicating them is worse than omitting them.
+WordPress emits it already. Canonical URLs, robots directives, sitemaps, feed links and the title tag
+are all core's job. Duplicating them is worse than omitting them.
 
 ## Verifying a change
 
-There is no test suite and no CI. Verification is manual, so say in the PR what you actually checked.
+There is no test suite and no CI, so verification is manual. Say in the PR what you actually checked.
 
 - **Front end:** home, a single post with comments, a category archive, a search result (including
   one with no results), a page, and a 404.
 - **PHP notices:** run with `WP_DEBUG` on and confirm the change adds none.
-- **Markup:** the theme has a history of duplicate-attribute and unbalanced-`div` bugs (#5, #6) —
-  view source rather than trusting that it looks right.
-- **RTL:** check the change at a mobile width too; the layout collapses to one column at 600px.
+- **Markup:** view source rather than trusting that it looks right. This theme has a history of
+  duplicate attributes and unbalanced `div`s that render fine until they do not.
+- **RTL:** check at a mobile width too; the layout collapses to one column at 600px.
 - **Editor:** if the change touches enqueues, `theme.json` or editor styles, open the post editor.
 
 ## Version bumping
 
-The version lives in **two** places and they must move together:
+The version lives in two places and they must move together:
 
-- `style.css` — the `Version:` line in the theme header
-- `functions.php` — the version argument passed to `wp_enqueue_style( 'abdeljalil-style', ... )`
+- `style.css`, the `Version:` line in the theme header
+- `functions.php`, the version argument passed to `wp_enqueue_style( 'abdeljalil-style', ... )`
 
 If they disagree, browsers serve a stale stylesheet after an update. Bump both in the same commit.
-
-`Tested up to:` in `style.css` should track the WordPress version the change was actually verified
-against — do not raise it speculatively.
+`Tested up to:` should track the WordPress version the change was actually verified against; do not
+raise it speculatively.
 
 ## Commits and pull requests
 
-Short imperative subject, no trailing period. Explain *why* in the body when the reason is not
-obvious from the diff. One logical change per PR.
+Short imperative subject, no trailing period. Explain why in the body when the reason is not obvious
+from the diff. One logical change per PR, and reference the issue it closes.
 
-Reference the issue the work belongs to (`Closes #12`). The tracker is organised into milestones
-M1–M5, ordered by payoff — start at the lowest open milestone unless there is a reason not to.
-
-Some issues deliberately overlap: #5, #14 and #16 all touch the same four listing templates, and #11
-and #14 touch the same icon markup. Each of those issues carries a note saying which to land first.
-Read it before starting, so the same lines are not rewritten twice.
+Issues that overlap with another carry a note saying which to land first. Read it before starting, so
+the same lines are not rewritten twice.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # Abdeljalil Theme — agent guide
 
-The rulebook for this repo is [`AGENTS.md`](AGENTS.md) and it is imported below, so it loads with
-this file on every session. Despite the filename, nothing in it is Claude-specific — Copilot reads a
-condensed copy at [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+The rulebook for this repo is [`AGENTS.md`](AGENTS.md), imported below so it loads on every session.
+Nothing in it is Claude-specific. Copilot reads a short pointer at
+[`.github/copilot-instructions.md`](.github/copilot-instructions.md), because Copilot Chat does not
+read `AGENTS.md` in every IDE.
 
 @AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Abdeljalil Theme — agent guide
+
+The rulebook for this repo is [`AGENTS.md`](AGENTS.md) and it is imported below, so it loads with
+this file on every session. Despite the filename, nothing in it is Claude-specific — Copilot reads a
+condensed copy at [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+
+@AGENTS.md


### PR DESCRIPTION
A simple version of the BattWatch agent-instructions setup, adapted to what this repo actually is.

## What is here

| File | Role |
|---|---|
| `AGENTS.md` | The rules. The cross-tool standard file, read by Claude Code (via the import below), Copilot CLI, Cursor and Codex. |
| `CLAUDE.md` | Four lines importing `AGENTS.md` with `@AGENTS.md`. This is the pattern Claude Code's own docs recommend for a repo that already has an `AGENTS.md`. |
| `.github/copilot-instructions.md` | A short pointer plus the three rules most often got wrong here. |

One substantive file rather than three that drift apart.

The Copilot file is not redundant, for a reason worth writing down: Copilot Chat does **not** read
`AGENTS.md` in JetBrains, Visual Studio, Eclipse or Xcode, and `@` file references expand only in
Copilot CLI. `.github/copilot-instructions.md` is the one instruction file every Copilot surface
reads, and this repo is developed in a JetBrains IDE. That rationale is a maintainer comment inside
the file so nobody later deletes it as duplication.

## What it says

Mostly things already true here but written down nowhere:

- Escape at the point of output, with the function matching the context. `esc_attr()` is not a CSS
  escaper.
- User-facing strings go through the `abdeljalil` text domain.
- CSS logical properties, not `left`/`right`. There is no `rtl.css`.
- WordPress PHP coding standards as the files already follow them: tabs, spaces inside parens, Yoda
  conditions, long-form `array()`.
- `functions.php` is organised by `/****...****/` banner comments; new code goes in the right
  section.
- The version lives in **two** places (`style.css` and the `wp_enqueue_style()` call) and they must
  move together, or browsers serve a stale stylesheet.
- Verification is manual, so the PR should say what was actually checked.

Plus three boundaries this repo has crossed before, now explicit: no plugin behaviour in the theme,
no remote assets, and do not reimplement what core already emits.

## What it deliberately does not say

BattWatch's guide is largely Conventional Commits and release-please versioning. Neither applies
here: no CI, no release automation, and the existing commits do not follow the convention, so
adopting it now would make history inconsistent for no enforcement benefit. `AGENTS.md` asks for a
short imperative subject and stops.

Happy to add the convention plus a PR-title check in a follow-up if that is wanted.

BattWatch also carries `CODE_REVIEW_GUIDELINES.md` and `CONTEXT.md`. Both are deliberately skipped
as more structure than this repo needs.

## Revised after review

The first commit was reviewed and the second addresses it:

- **Corrected a false claim.** The original said this setup needed a third file "because Copilot has
  no import mechanism". Copilot CLI does support `@` references; the real reason is the IDE coverage
  gap described above.
- **Dropped the layout table.** Directory listings are derivable from the repo. Only `functions.php`
  being an 800-line grab-bag is not, so that survives as one sentence.
- **Removed every issue number.** Rules and backlog state change on different clocks, and one line
  would have become false the day #11 merged.
- **Cut the Copilot file** to three rules plus a pointer, so the two files have less to drift on.
- **Fixed a contradiction with #12**, which needs a WOFF2 build step that the guide had flatly
  forbidden.
- **Cut filler.** 1,065 to 883 words across the three files.

## Verification

Documentation only. No PHP, CSS or template changes, so no runtime behaviour is affected.

`CLAUDE.md`'s `@AGENTS.md` import is outside backticks so it resolves; the two `AGENTS.md` mentions
above it are inside backticks or markdown links, which Claude Code's import parser skips.
