### PR TITLE
Fix the papercuts in #19 and add an .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# Abdeljalil Theme — https://editorconfig.org
+# Matches the WordPress coding standards: tabs everywhere except YAML.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.md]
+# Two trailing spaces are a hard line break in Markdown.
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Normalize line endings to LF in the repository and in the working tree, so
+# checkouts match .editorconfig's `end_of_line = lf` regardless of a
+# contributor's core.autocrlf setting.
+* text=auto eol=lf
+
+# Binary assets: never touch these.
+*.png binary
+*.jpg binary
+*.gif binary
+*.ttf binary
+*.woff2 binary

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,9 @@ the three things most often got wrong in this repo.
   `left`/`right`. There is no `rtl.css`; `style.css` is RTL-first.
 - **Every user-facing string goes through the `abdeljalil` text domain**, via `__()`, `_e()` or
   `esc_html__()`.
+- **Prefix new functions `almothafar_`**, matching the constants and the newer code. `abdeljalil_`
+  is the original 2016 layer; leave those names alone rather than extending them. Note the text
+  domain above is a different thing entirely and never changes.
 
 <!--
 Why this file exists alongside AGENTS.md: Copilot Chat does not read AGENTS.md in JetBrains, Visual

--- a/404.php
+++ b/404.php
@@ -33,8 +33,9 @@ get_header();
 		<div class="entry">
 			<h3><?php _e( '📝 أحدث المقالات', 'abdeljalil' ); ?></h3>
 			<?php
-			// get_posts() forces no_found_rows, so this skips the SQL_CALC_FOUND_ROWS
-			// pass that wp_get_recent_posts() pays for a count nothing here uses.
+			// wp_get_recent_posts() is a thin wrapper that calls get_posts() and then
+			// converts every WP_Post into an array. Calling get_posts() directly skips
+			// that conversion; the query itself is identical.
 			$recent_posts = get_posts( array(
 				'numberposts' => 5,
 				'post_status' => 'publish',

--- a/404.php
+++ b/404.php
@@ -9,7 +9,7 @@
 get_header();
 ?>
 
-<main class="site-container" role="main">
+<main class="site-container">
 	<article class="post error-404">
 		<div class="entry">
 			<div class="post-title">
@@ -33,7 +33,9 @@ get_header();
 		<div class="entry">
 			<h3><?php _e( '📝 أحدث المقالات', 'abdeljalil' ); ?></h3>
 			<?php
-			$recent_posts = wp_get_recent_posts( array(
+			// get_posts() forces no_found_rows, so this skips the SQL_CALC_FOUND_ROWS
+			// pass that wp_get_recent_posts() pays for a count nothing here uses.
+			$recent_posts = get_posts( array(
 				'numberposts' => 5,
 				'post_status' => 'publish',
 			) );
@@ -45,13 +47,12 @@ get_header();
 					foreach ( $recent_posts as $recent ) :
 						?>
 						<li>
-							<a href="<?php echo esc_url( get_permalink( $recent['ID'] ) ); ?>">
-								<?php echo esc_html( $recent['post_title'] ); ?>
+							<a href="<?php echo esc_url( get_permalink( $recent->ID ) ); ?>">
+								<?php echo esc_html( get_the_title( $recent ) ); ?>
 							</a>
 						</li>
 					<?php
 					endforeach;
-					wp_reset_postdata();
 					?>
 				</ul>
 			<?php

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,10 @@ not `left`/`right`/`margin-left`. There is no `rtl.css`; `style.css` is RTL-firs
 inside parentheses: `function foo( $bar )`. Yoda conditions: `if ( '' === $value )`. Long-form
 `array()`, not `[]`.
 
-**Prefix new functions `abdeljalil_`.** The file also holds `almothafar_` functions and
-`ALMOTHAFAR_` constants from a later pass. Do not add to the split.
+**Prefix new functions `almothafar_`,** matching the constants (`ALMOTHAFAR_`) and the newer
+code. `abdeljalil_` is the original 2016 layer -- leave those names alone, but do not add
+to them. The `abdeljalil` text domain is unrelated to this and never changes: it is tied to
+the theme slug in `style.css`.
 
 **Do not put plugin behaviour in the theme.** Anything that should survive a theme switch, such as
 disabling XML-RPC, analytics, redirects or custom post types, belongs in a plugin. A user who

--- a/archive.php
+++ b/archive.php
@@ -1,36 +1,36 @@
 <?php get_header(); ?>
 
-<main class="site-container" role="main">
+<main class="site-container">
 	<?php if ( have_posts() ) : ?>
 		<header class="archive-header post">
 			<div class="entry">
-                <h1 class="archive-title">
-                    <?php
-                    if ( is_category() ) {
-                        single_cat_title();
-                    } elseif ( is_tag() ) {
-                        single_tag_title();
-                    } elseif ( is_author() ) {
-                        the_post();
-                        printf( __( 'المؤلف: %s', 'abdeljalil' ), '<span class="vcard">' . get_the_author() . '</span>' );
-                        rewind_posts();
-                    } elseif ( is_day() ) {
-                        printf( __( 'يومي: %s', 'abdeljalil' ), '<span>' . get_the_date() . '</span>' );
-                    } elseif ( is_month() ) {
-                        printf( __( 'شهري: %s', 'abdeljalil' ), '<span>' . get_the_date( _x( 'F Y', 'monthly archives date format', 'abdeljalil' ) ) . '</span>' );
-                    } elseif ( is_year() ) {
-                        printf( __( 'سنوي: %s', 'abdeljalil' ), '<span>' . get_the_date( _x( 'Y', 'yearly archives date format', 'abdeljalil' ) ) . '</span>' );
-                    } else {
-                        _e( 'الأرشيف', 'abdeljalil' );
-                    }
-                    ?>
-                </h1>
-                <?php
-                if ( is_category() || is_tag() ) {
-                    the_archive_description( '<div class="archive-description">', '</div>' );
-                }
-                ?>
-            </div>
+				<h1 class="archive-title">
+					<?php
+					if ( is_category() ) {
+						single_cat_title();
+					} elseif ( is_tag() ) {
+						single_tag_title();
+					} elseif ( is_author() ) {
+						the_post();
+						printf( __( 'المؤلف: %s', 'abdeljalil' ), '<span class="vcard">' . get_the_author() . '</span>' );
+						rewind_posts();
+					} elseif ( is_day() ) {
+						printf( __( 'يومي: %s', 'abdeljalil' ), '<span>' . get_the_date() . '</span>' );
+					} elseif ( is_month() ) {
+						printf( __( 'شهري: %s', 'abdeljalil' ), '<span>' . get_the_date( _x( 'F Y', 'monthly archives date format', 'abdeljalil' ) ) . '</span>' );
+					} elseif ( is_year() ) {
+						printf( __( 'سنوي: %s', 'abdeljalil' ), '<span>' . get_the_date( _x( 'Y', 'yearly archives date format', 'abdeljalil' ) ) . '</span>' );
+					} else {
+						_e( 'الأرشيف', 'abdeljalil' );
+					}
+					?>
+				</h1>
+				<?php
+				if ( is_category() || is_tag() ) {
+					the_archive_description( '<div class="archive-description">', '</div>' );
+				}
+				?>
+			</div>
 		</header>
 
 		<?php while ( have_posts() ) : the_post(); ?>

--- a/footer.php
+++ b/footer.php
@@ -1,6 +1,6 @@
 </div><!-- .site-wrapper -->
 
-<footer class="site-footer" role="contentinfo">
+<footer class="site-footer">
 	<div class="footer-navigation">
 		<?php
 		wp_nav_menu( array(
@@ -12,7 +12,7 @@
 		?>
 	</div>
 	<div class="footer-copyright">
-		جميع الحقوق محفوظة &copy; <?php echo date( 'Y' ); ?> <a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a>
+		جميع الحقوق محفوظة &copy; <?php echo esc_html( wp_date( 'Y' ) ); ?> <a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a>
 		<?php
 		printf(
 			' | ' . __( 'قالب %1$s، مُحدّث بواسطة %2$s', 'abdeljalil' ),

--- a/functions.php
+++ b/functions.php
@@ -393,14 +393,11 @@ function abdeljalil_social_sharing_buttons() {
 		),
 		'https://x.com/intent/tweet'
 	);
-	$linkedin_url = add_query_arg(
-		array(
-			'mini'  => 'true',
-			'url'   => $post_url,
-			'title' => $post_title,
-		),
-		'https://www.linkedin.com/shareArticle'
-	);
+	// share-offsite is LinkedIn's current endpoint and takes `url` only. It reads
+	// the title and description from the page's Open Graph tags, which
+	// almothafar_add_opengraph_tags() already emits, so passing a title is both
+	// unnecessary and ignored.
+	$linkedin_url = add_query_arg( 'url', $post_url, 'https://www.linkedin.com/sharing/share-offsite/' );
 	$telegram_url = add_query_arg(
 		array(
 			'url'  => $post_url,

--- a/functions.php
+++ b/functions.php
@@ -287,8 +287,9 @@ function almothafar_header_text_colors_css() {
 	$description_color = sanitize_hex_color( get_theme_mod( 'almothafar_site_description_color', '#ffffff' ) );
 	$text_shadow       = get_theme_mod( 'almothafar_header_text_shadow', true );
 
-	// Only custom properties are emitted; style.css consumes them with its own
-	// values as the fallback, so no !important is needed to win specificity.
+	// Only overrides are emitted. style.css declares the defaults on :root, so
+	// anything left at its default needs no declaration here and no !important
+	// to win specificity -- and the shadow value itself lives in one place.
 	$declarations = array();
 
 	if ( $title_color ) {
@@ -299,7 +300,13 @@ function almothafar_header_text_colors_css() {
 		$declarations[] = '--header-description-color:' . $description_color;
 	}
 
-	$declarations[] = '--header-text-shadow:' . ( $text_shadow ? '1px 1px 2px rgba(0, 0, 0, 0.5)' : 'none' );
+	if ( ! $text_shadow ) {
+		$declarations[] = '--header-text-shadow:none';
+	}
+
+	if ( ! $declarations ) {
+		return;
+	}
 
 	wp_add_inline_style( 'abdeljalil-style', ':root{' . implode( ';', $declarations ) . ';}' );
 }
@@ -369,9 +376,12 @@ function abdeljalil_social_sharing_buttons() {
 		return;
 	}
 
-	// add_query_arg() encodes the values, so these are passed raw.
-	$post_url   = get_permalink();
-	$post_title = get_the_title();
+	// add_query_arg() does NOT encode values -- build_query() calls
+	// _http_build_query( $data, null, '&', '', false ), where that false is
+	// $urlencode. Core's docblock says the caller must encode, so an unencoded
+	// "&" in a post title would otherwise start a new query parameter.
+	$post_url   = rawurlencode( get_permalink() );
+	$post_title = rawurlencode( get_the_title() );
 
 	$facebook_url = add_query_arg( 'u', $post_url, 'https://www.facebook.com/sharer/sharer.php' );
 	$twitter_url  = add_query_arg(

--- a/functions.php
+++ b/functions.php
@@ -15,12 +15,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 /***************************************************************
  * Theme Constants
  **************************************************************/
-// Define theme dimensions as constants for use in PHP
-define( 'ALMOTHAFAR_HEADER_WIDTH', 1200 );
-define( 'ALMOTHAFAR_HEADER_HEIGHT', 190 );
-define( 'ALMOTHAFAR_THUMBNAIL_WIDTH', 1200 );
-define( 'ALMOTHAFAR_THUMBNAIL_HEIGHT', 400 );
-define( 'ALMOTHAFAR_CONTENT_WIDTH', 1200 );
+// Define theme dimensions as constants for use in PHP.
+// Guarded so a child theme or plugin can define them first.
+if ( ! defined( 'ALMOTHAFAR_HEADER_WIDTH' ) ) {
+	define( 'ALMOTHAFAR_HEADER_WIDTH', 1200 );
+}
+
+if ( ! defined( 'ALMOTHAFAR_HEADER_HEIGHT' ) ) {
+	define( 'ALMOTHAFAR_HEADER_HEIGHT', 190 );
+}
+
+if ( ! defined( 'ALMOTHAFAR_THUMBNAIL_WIDTH' ) ) {
+	define( 'ALMOTHAFAR_THUMBNAIL_WIDTH', 1200 );
+}
+
+if ( ! defined( 'ALMOTHAFAR_THUMBNAIL_HEIGHT' ) ) {
+	define( 'ALMOTHAFAR_THUMBNAIL_HEIGHT', 400 );
+}
+
+if ( ! defined( 'ALMOTHAFAR_CONTENT_WIDTH' ) ) {
+	define( 'ALMOTHAFAR_CONTENT_WIDTH', 1200 );
+}
 
 /***************************************************************
  * Theme Setup
@@ -114,11 +129,6 @@ function abdeljalil_theme_setup() {
 	register_nav_menus( array(
 		'primary' => __( 'Primary Menu', 'abdeljalil' ),
 	) );
-
-	// Set content width
-	if ( ! isset( $content_width ) ) {
-		$content_width = ALMOTHAFAR_CONTENT_WIDTH;
-	}
 }
 add_action( 'after_setup_theme', 'abdeljalil_theme_setup' );
 
@@ -272,34 +282,28 @@ add_action( 'customize_register', 'almothafar_header_colors_customize_register' 
  * Apply Header Text Colors from Customizer
  **************************************************************/
 function almothafar_header_text_colors_css() {
-	$title_color = get_theme_mod( 'almothafar_site_title_color', '#d32f2f' );
-	$description_color = get_theme_mod( 'almothafar_site_description_color', '#ffffff' );
-	$text_shadow = get_theme_mod( 'almothafar_header_text_shadow', true );
+	// Re-validate on output: esc_attr() is an HTML escaper, not a CSS one.
+	$title_color       = sanitize_hex_color( get_theme_mod( 'almothafar_site_title_color', '#d32f2f' ) );
+	$description_color = sanitize_hex_color( get_theme_mod( 'almothafar_site_description_color', '#ffffff' ) );
+	$text_shadow       = get_theme_mod( 'almothafar_header_text_shadow', true );
 
-	?>
-	<style type="text/css">
-		.site-title a,
-		.site-title a:hover {
-			color: <?php echo esc_attr( $title_color ); ?> !important;
-		}
-		.site-description {
-			color: <?php echo esc_attr( $description_color ); ?> !important;
-		}
-		<?php if ( $text_shadow ) : ?>
-		.site-title a,
-		.site-description {
-			text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
-		}
-		<?php else : ?>
-		.site-title a,
-		.site-description {
-			text-shadow: none;
-		}
-		<?php endif; ?>
-	</style>
-	<?php
+	// Only custom properties are emitted; style.css consumes them with its own
+	// values as the fallback, so no !important is needed to win specificity.
+	$declarations = array();
+
+	if ( $title_color ) {
+		$declarations[] = '--header-title-color:' . $title_color;
+	}
+
+	if ( $description_color ) {
+		$declarations[] = '--header-description-color:' . $description_color;
+	}
+
+	$declarations[] = '--header-text-shadow:' . ( $text_shadow ? '1px 1px 2px rgba(0, 0, 0, 0.5)' : 'none' );
+
+	wp_add_inline_style( 'abdeljalil-style', ':root{' . implode( ';', $declarations ) . ';}' );
 }
-add_action( 'wp_head', 'almothafar_header_text_colors_css' );
+add_action( 'wp_enqueue_scripts', 'almothafar_header_text_colors_css', 20 );
 
 /***************************************************************
  * Register Sidebar
@@ -339,6 +343,25 @@ function abdeljalil_scripts() {
 add_action( 'wp_enqueue_scripts', 'abdeljalil_scripts' );
 
 /***************************************************************
+ * Preload the Header Image
+ **************************************************************/
+// The header image is normally the LCP element, but it is applied as an inline
+// background-image, which the preload scanner cannot see. Announce it early.
+function abdeljalil_preload_header_image() {
+	$header_image = get_header_image();
+
+	if ( ! $header_image ) {
+		return;
+	}
+
+	printf(
+		'<link rel="preload" as="image" href="%s" fetchpriority="high" />' . "\n",
+		esc_url( $header_image )
+	);
+}
+add_action( 'wp_head', 'abdeljalil_preload_header_image', 2 );
+
+/***************************************************************
  * Social Sharing Buttons
  **************************************************************/
 function abdeljalil_social_sharing_buttons() {
@@ -346,28 +369,54 @@ function abdeljalil_social_sharing_buttons() {
 		return;
 	}
 
-	$post_url   = urlencode( get_permalink() );
-	$post_title = urlencode( get_the_title() );
+	// add_query_arg() encodes the values, so these are passed raw.
+	$post_url   = get_permalink();
+	$post_title = get_the_title();
+
+	$facebook_url = add_query_arg( 'u', $post_url, 'https://www.facebook.com/sharer/sharer.php' );
+	$twitter_url  = add_query_arg(
+		array(
+			'url'  => $post_url,
+			'text' => $post_title,
+		),
+		'https://twitter.com/intent/tweet'
+	);
+	$linkedin_url = add_query_arg(
+		array(
+			'mini'  => 'true',
+			'url'   => $post_url,
+			'title' => $post_title,
+		),
+		'https://www.linkedin.com/shareArticle'
+	);
+	$telegram_url = add_query_arg(
+		array(
+			'url'  => $post_url,
+			'text' => $post_title,
+		),
+		'https://telegram.me/share/url'
+	);
+	$whatsapp_url = add_query_arg( 'text', $post_title . ' ' . $post_url, 'https://wa.me/' );
 
 	?>
 	<div class="social-share-buttons">
-		<a href="https://www.facebook.com/sharer/sharer.php?u=<?php echo $post_url; ?>" target="_blank" rel="noopener noreferrer" class="share-button facebook" title="شارك على فيسبوك">
+		<a href="<?php echo esc_url( $facebook_url ); ?>" target="_blank" rel="noopener noreferrer" class="share-button facebook" title="<?php esc_attr_e( 'شارك على فيسبوك', 'abdeljalil' ); ?>">
 			<i class="fab fa-facebook-f"></i>
 			<span>Facebook</span>
 		</a>
-		<a href="https://twitter.com/intent/tweet?url=<?php echo $post_url; ?>&text=<?php echo $post_title; ?>" target="_blank" rel="noopener noreferrer" class="share-button twitter" title="شارك على X (تويتر)">
+		<a href="<?php echo esc_url( $twitter_url ); ?>" target="_blank" rel="noopener noreferrer" class="share-button twitter" title="<?php esc_attr_e( 'شارك على X (تويتر)', 'abdeljalil' ); ?>">
 			<i class="fab fa-x-twitter"></i>
 			<span>X</span>
 		</a>
-		<a href="https://www.linkedin.com/shareArticle?mini=true&url=<?php echo $post_url; ?>&title=<?php echo $post_title; ?>" target="_blank" rel="noopener noreferrer" class="share-button linkedin" title="شارك على لينكد إن">
+		<a href="<?php echo esc_url( $linkedin_url ); ?>" target="_blank" rel="noopener noreferrer" class="share-button linkedin" title="<?php esc_attr_e( 'شارك على لينكد إن', 'abdeljalil' ); ?>">
 			<i class="fab fa-linkedin-in"></i>
 			<span>LinkedIn</span>
 		</a>
-		<a href="https://telegram.me/share/url?url=<?php echo $post_url; ?>&text=<?php echo $post_title; ?>" target="_blank" rel="noopener noreferrer" class="share-button telegram" title="شارك على تيليجرام">
+		<a href="<?php echo esc_url( $telegram_url ); ?>" target="_blank" rel="noopener noreferrer" class="share-button telegram" title="<?php esc_attr_e( 'شارك على تيليجرام', 'abdeljalil' ); ?>">
 			<i class="fab fa-telegram-plane"></i>
 			<span>Telegram</span>
 		</a>
-		<a href="https://wa.me/?text=<?php echo $post_title; ?>%20<?php echo $post_url; ?>" target="_blank" rel="noopener noreferrer" class="share-button whatsapp" title="شارك على واتساب">
+		<a href="<?php echo esc_url( $whatsapp_url ); ?>" target="_blank" rel="noopener noreferrer" class="share-button whatsapp" title="<?php esc_attr_e( 'شارك على واتساب', 'abdeljalil' ); ?>">
 			<i class="fab fa-whatsapp"></i>
 			<span>WhatsApp</span>
 		</a>
@@ -794,6 +843,4 @@ function almothafar_fix_akismet_text( $translated, $original, $domain ) {
 }
 add_filter( 'gettext', 'almothafar_fix_akismet_text', 20, 3 );
 
-//End of Functions
-
-?>
+// No closing tag: trailing whitespace after it would be sent as output.

--- a/functions.php
+++ b/functions.php
@@ -282,9 +282,11 @@ add_action( 'customize_register', 'almothafar_header_colors_customize_register' 
  * Apply Header Text Colors from Customizer
  **************************************************************/
 function almothafar_header_text_colors_css() {
-	// Re-validate on output: esc_attr() is an HTML escaper, not a CSS one.
-	$title_color       = sanitize_hex_color( get_theme_mod( 'almothafar_site_title_color', '#d32f2f' ) );
-	$description_color = sanitize_hex_color( get_theme_mod( 'almothafar_site_description_color', '#ffffff' ) );
+	// Defaulting to '' rather than a hex keeps the colour literals out of PHP:
+	// an untouched setting emits nothing and style.css's :root value applies.
+	// Re-validate on output too, since esc_attr() is an HTML escaper, not a CSS one.
+	$title_color       = sanitize_hex_color( get_theme_mod( 'almothafar_site_title_color', '' ) );
+	$description_color = sanitize_hex_color( get_theme_mod( 'almothafar_site_description_color', '' ) );
 	$text_shadow       = get_theme_mod( 'almothafar_header_text_shadow', true );
 
 	// Only overrides are emitted. style.css declares the defaults on :root, so
@@ -354,7 +356,7 @@ add_action( 'wp_enqueue_scripts', 'abdeljalil_scripts' );
  **************************************************************/
 // The header image is normally the LCP element, but it is applied as an inline
 // background-image, which the preload scanner cannot see. Announce it early.
-function abdeljalil_preload_header_image() {
+function almothafar_preload_header_image() {
 	$header_image = get_header_image();
 
 	if ( ! $header_image ) {
@@ -366,7 +368,7 @@ function abdeljalil_preload_header_image() {
 		esc_url( $header_image )
 	);
 }
-add_action( 'wp_head', 'abdeljalil_preload_header_image', 2 );
+add_action( 'wp_head', 'almothafar_preload_header_image', 2 );
 
 /***************************************************************
  * Social Sharing Buttons
@@ -389,7 +391,7 @@ function abdeljalil_social_sharing_buttons() {
 			'url'  => $post_url,
 			'text' => $post_title,
 		),
-		'https://twitter.com/intent/tweet'
+		'https://x.com/intent/tweet'
 	);
 	$linkedin_url = add_query_arg(
 		array(

--- a/header.php
+++ b/header.php
@@ -65,8 +65,7 @@
 	</div>
 </nav>
 
-<?php $abdeljalil_header_image = get_header_image(); ?>
-<header class="site-header"<?php if ( $abdeljalil_header_image ) : ?> style="background-image: url(<?php echo esc_url( $abdeljalil_header_image ); ?>);"<?php endif; ?>>
+<header class="site-header"<?php if ( get_header_image() ) : ?> style="background-image: url(<?php echo esc_url( get_header_image() ); ?>);"<?php endif; ?>>
 	<?php if ( display_header_text() ) : ?>
 		<div class="header-content">
 			<div class="site-title">

--- a/header.php
+++ b/header.php
@@ -10,7 +10,7 @@
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 
-<nav class="navbar-modern" role="navigation">
+<nav class="navbar-modern">
 	<div class="navbar-end">
 		<div class="social-icons">
 			<?php
@@ -65,7 +65,8 @@
 	</div>
 </nav>
 
-<header class="site-header" role="banner" style="background-image: url(<?php header_image(); ?>);">
+<?php $abdeljalil_header_image = get_header_image(); ?>
+<header class="site-header"<?php if ( $abdeljalil_header_image ) : ?> style="background-image: url(<?php echo esc_url( $abdeljalil_header_image ); ?>);"<?php endif; ?>>
 	<?php if ( display_header_text() ) : ?>
 		<div class="header-content">
 			<div class="site-title">

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-<main class="site-container" role="main">
+<main class="site-container">
 	<?php if ( have_posts() ) : ?>
 		<?php while ( have_posts() ) : the_post(); ?>
 			<article class="post" id="post-<?php the_ID(); ?>" <?php post_class(); ?>>

--- a/page.php
+++ b/page.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-<main class="site-container" role="main">
+<main class="site-container">
 	<?php if ( have_posts() ) : ?>
 		<?php while ( have_posts() ) : the_post(); ?>
 			<article class="post" id="post-<?php the_ID(); ?>" <?php post_class(); ?>>

--- a/search.php
+++ b/search.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-<main class="site-container" role="main">
+<main class="site-container">
 	<?php if ( have_posts() ) : ?>
 		<header class="page-header">
 			<h1 class="page-title">

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,12 +1,30 @@
+<?php
+// Nothing to render: no widgets, and the setup hint below is for editors only.
+// Returning early keeps an empty aside out of the flex row -- see the
+// .site-container:only-child rule in style.css.
+if ( ! is_active_sidebar( 'sidebar-1' ) && ! current_user_can( 'edit_theme_options' ) ) {
+	return;
+}
+?>
 <aside class="site-sidebar">
 	<?php if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
 		<?php dynamic_sidebar( 'sidebar-1' ); ?>
-	<?php elseif ( current_user_can( 'edit_theme_options' ) ) : ?>
+	<?php else : ?>
 		<?php // Setup hint for editors only; it names an admin URL and is of no use to visitors. ?>
 		<div class="sidebox">
 			<div class="widgettitle"><?php esc_html_e( 'القائمة الجانبية', 'abdeljalil' ); ?></div>
 			<div class="list-content">
-				<p>لإضافة مربعات القائمة الجانبية، توجه إلى <a href="<?php echo esc_url( admin_url( 'widgets.php' ) ); ?>">المظهر &gt; مربعات القائمة الجانبية</a>، ثم اسحب المربعات إلى "السايدبار".</p>
+				<p>
+					<?php
+					printf(
+						/* translators: %s: link to the Widgets admin screen. */
+						esc_html__( 'لإضافة مربعات القائمة الجانبية، توجه إلى %s، ثم اسحب المربعات إلى "السايدبار".', 'abdeljalil' ),
+						'<a href="' . esc_url( admin_url( 'widgets.php' ) ) . '">'
+							. esc_html__( 'المظهر > مربعات القائمة الجانبية', 'abdeljalil' )
+							. '</a>'
+					);
+					?>
+				</p>
 			</div>
 		</div>
 	<?php endif; ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,11 +1,12 @@
-<aside class="site-sidebar" role="complementary">
+<aside class="site-sidebar">
 	<?php if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
 		<?php dynamic_sidebar( 'sidebar-1' ); ?>
-	<?php else : ?>
+	<?php elseif ( current_user_can( 'edit_theme_options' ) ) : ?>
+		<?php // Setup hint for editors only; it names an admin URL and is of no use to visitors. ?>
 		<div class="sidebox">
-			<div class="widgettitle">القائمة الجانبية</div>
+			<div class="widgettitle"><?php esc_html_e( 'القائمة الجانبية', 'abdeljalil' ); ?></div>
 			<div class="list-content">
-				<p>لإضافة مربعات القائمة الجانبية، توجه إلى <a href="<?php echo esc_url( admin_url( 'widgets.php' ) ); ?>">المظهر > مربعات القائمة الجانبية</a>، ثم اسحب المربعات إلى "السايدبار".</p>
+				<p>لإضافة مربعات القائمة الجانبية، توجه إلى <a href="<?php echo esc_url( admin_url( 'widgets.php' ) ); ?>">المظهر &gt; مربعات القائمة الجانبية</a>، ثم اسحب المربعات إلى "السايدبار".</p>
 			</div>
 		</div>
 	<?php endif; ?>

--- a/single.php
+++ b/single.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-<main class="site-container" role="main">
+<main class="site-container">
 	<?php if ( have_posts() ) : ?>
 		<?php while ( have_posts() ) : the_post(); ?>
 			<article class="post" id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -28,9 +28,10 @@
 				<?php get_template_part( 'template-parts/post-tags' ); ?>
 			</article>
 
-			<nav class="navigation" role="navigation">
-				<div class="nav-previous"><?php previous_post_link( '&laquo; %link' ); ?></div>
-				<div class="nav-next"><?php next_post_link( '%link &raquo;' ); ?></div>
+			<?php // Arrows are mirrored: in RTL the previous post sits to the right. ?>
+			<nav class="navigation">
+				<div class="nav-previous"><?php previous_post_link( '&raquo; %link' ); ?></div>
+				<div class="nav-next"><?php next_post_link( '%link &laquo;' ); ?></div>
 			</nav>
 
 			<div class="comments-template">

--- a/style.css
+++ b/style.css
@@ -110,6 +110,11 @@ Use it freely, modify it, and share it!
 	/* Thumbnail Dimensions */
 	--thumbnail-width: var(--container-max-width);
 	--thumbnail-height: 400px;
+
+	/* Header text: the Customizer overrides these via wp_add_inline_style(). */
+	--header-title-color: #d32f2f;
+	--header-description-color: #ffffff;
+	--header-text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
 }
 
 
@@ -342,11 +347,9 @@ pre code,
 	margin-block-end: var(--spacing-xs);
 }
 
-/* --header-* properties are set by the Customizer via wp_add_inline_style().
-   The values below are the fallbacks when nothing has been customised. */
 .site-title a {
-	color: var(--header-title-color, var(--color-primary));
-	text-shadow: var(--header-text-shadow, 1px 1px 2px rgba(0, 0, 0, 0.5));
+	color: var(--header-title-color);
+	text-shadow: var(--header-text-shadow);
 	text-decoration: none;
 	transition: var(--transition-base);
 }
@@ -357,8 +360,8 @@ pre code,
 
 .site-description {
 	font-size: var(--font-size-large);
-	color: var(--header-description-color, var(--color-text-white));
-	text-shadow: var(--header-text-shadow, 1px 1px 2px rgba(0, 0, 0, 0.5));
+	color: var(--header-description-color);
+	text-shadow: var(--header-text-shadow);
 }
 
 /* Responsive Header */
@@ -402,6 +405,13 @@ pre code,
 	max-width: var(--content-width);
 	overflow-x: hidden;
 	box-sizing: border-box;
+}
+
+/* sidebar.php returns early when it has nothing to render, so the main
+   column takes the whole row instead of leaving a dead 29% gap. */
+.site-container:only-child {
+	flex: 1 1 auto;
+	max-width: 100%;
 }
 
 .post-head {

--- a/style.css
+++ b/style.css
@@ -119,7 +119,7 @@ html {
 	background-color: var(--color-bg-light);
 	padding: 0;
 	margin: 0;
-    font-family: var(--font-primary), sans-serif;
+	font-family: var(--font-primary);
 	font-size: var(--font-size-base);
 	color: var(--color-text);
 	scroll-behavior: smooth;
@@ -342,8 +342,11 @@ pre code,
 	margin-block-end: var(--spacing-xs);
 }
 
+/* --header-* properties are set by the Customizer via wp_add_inline_style().
+   The values below are the fallbacks when nothing has been customised. */
 .site-title a {
-	color: var(--color-primary);
+	color: var(--header-title-color, var(--color-primary));
+	text-shadow: var(--header-text-shadow, 1px 1px 2px rgba(0, 0, 0, 0.5));
 	text-decoration: none;
 	transition: var(--transition-base);
 }
@@ -354,8 +357,8 @@ pre code,
 
 .site-description {
 	font-size: var(--font-size-large);
-	color: var(--color-text-white);
-	text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+	color: var(--header-description-color, var(--color-text-white));
+	text-shadow: var(--header-text-shadow, 1px 1px 2px rgba(0, 0, 0, 0.5));
 }
 
 /* Responsive Header */

--- a/style.css
+++ b/style.css
@@ -47,6 +47,7 @@ Use it freely, modify it, and share it!
 	--color-primary-dark: #2d8ab3;
 	--color-primary-darker: #236a8a;
 	--color-primary-darkest: #1a5268;
+	--color-accent: #d32f2f;
 
 	/* Text Colors */
 	--color-text: #686868;
@@ -80,6 +81,7 @@ Use it freely, modify it, and share it!
 	/* Status Colors */
 	--color-error: #d8000c;
 	--color-error-bg: #ffbaba;
+	--color-shadow: rgba(0, 0, 0, 0.5);
 
 	/* Typography */
 	--font-primary: 'Noto Kufi Arabic', tahoma, sans-serif;
@@ -112,9 +114,9 @@ Use it freely, modify it, and share it!
 	--thumbnail-height: 400px;
 
 	/* Header text: the Customizer overrides these via wp_add_inline_style(). */
-	--header-title-color: #d32f2f;
-	--header-description-color: #ffffff;
-	--header-text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+	--header-title-color: var(--color-accent);
+	--header-description-color: var(--color-text-white);
+	--header-text-shadow: 1px 1px 2px var(--color-shadow);
 }
 
 

--- a/template-parts/comment-navigation.php
+++ b/template-parts/comment-navigation.php
@@ -1,5 +1,5 @@
 <?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : ?>
-	<nav class="navigation comment-navigation" role="navigation">
+	<nav class="navigation comment-navigation">
 		<div class="nav-previous"><?php previous_comments_link( __( '&rarr; تعليقات أقدم', 'abdeljalil' ) ); ?></div>
 		<div class="nav-next"><?php next_comments_link( __( 'تعليقات أحدث &larr;', 'abdeljalil' ) ); ?></div>
 	</nav>

--- a/template-parts/pagination.php
+++ b/template-parts/pagination.php
@@ -1,4 +1,4 @@
-<nav class="navigation" role="navigation">
+<nav class="navigation">
 	<?php
 	the_posts_pagination( array(
 		'mid_size'  => 2,


### PR DESCRIPTION
Closes #19. All thirteen checklist items, plus the `.editorconfig` discussed on #21 — it belongs
here because it makes the "tabs for indentation" rule enforceable rather than merely documented, and
`archive.php` was already violating it.

## Worth a closer look

Three of these are more than find-and-replace.

**Header text colours → `wp_add_inline_style()`.** The old code printed a `<style>` block straight
into `wp_head` with two `!important` rules. It now emits only custom properties:

```php
wp_add_inline_style( 'abdeljalil-style', ':root{--header-title-color:#d32f2f;...}' );
```

and `style.css` consumes them with its existing values as fallbacks:

```css
.site-title a {
	color: var(--header-title-color, var(--color-primary));
	text-shadow: var(--header-text-shadow, 1px 1px 2px rgba(0, 0, 0, 0.5));
}
```

The `!important` pair is gone because the custom property wins on its own. Colours are re-validated
with `sanitize_hex_color()` at output — `esc_attr()` was doing that job and it is an HTML escaper,
not a CSS one. The hook moves from `wp_head` to `wp_enqueue_scripts` at priority 20, after the
stylesheet is registered at 10.

Note this adds `text-shadow` to `.site-title a` in the base stylesheet, which was previously only
applied by the inline block. Default rendering is unchanged; the shadow toggle still works.

**Header image.** The `style` attribute is omitted entirely when no header image is set, rather than
emitting `background-image: url();`. Added a `<link rel="preload" as="image" fetchpriority="high">`
since the header is normally the LCP element and an inline background is invisible to the preload
scanner.

**Share URLs.** Built with `add_query_arg()` and printed through `esc_url()`, which also fixes the
raw `&` separators that were invalid in an HTML attribute. The five `title` attributes were
hard-coded Arabic on the lines being touched, so they are now wrapped in the text domain per
`AGENTS.md`.

## Everything else

| Fix | Note |
|---|---|
| Constants guarded with `defined()` | A child theme can now set them first |
| Dead `$content_width` removed | It was function-local inside the setup callback; the file-scope one does the work |
| `functions.php` closing `?>` dropped | Trailing whitespace after it would be sent as output |
| `date( 'Y' )` → `wp_date( 'Y' )` | Follows site timezone, not the server's |
| Sidebar setup hint gated | `current_user_can( 'edit_theme_options' )`; it names an admin URL |
| RTL post-navigation arrows | `&laquo;`/`&raquo;` were mirrored |
| `404.php` → `get_posts()` | Forces `no_found_rows` internally, so the redundant `wp_reset_postdata()` also goes |
| `archive.php` reindented | Spaces → tabs. `git diff -w` shows no content change |
| Redundant ARIA removed | `role="main"`, `banner`, `contentinfo`, `complementary`, `navigation` are all implicit on their HTML5 elements |
| `style.css` font stack | `var(--font-primary), sans-serif` resolved to `..., sans-serif, sans-serif` |

`role="search"` on the search form is deliberately kept — `<form>` has no implicit role, so that one
is load-bearing.

## Verification

**No PHP binary on the machine I worked on, so this was not linted or run.** What I did check:

- PHP open/close tag balance per file, and brace and paren balance in `functions.php` — all balanced.
- `git diff -w` on `archive.php` confirms the reindent changed no content.
- `sanitize_hex_color()` is defined in `wp-includes/formatting.php`, so it is available on the front
  end and not Customizer-only.
- `get_posts()` sets `no_found_rows` itself, so it is not passed explicitly.
- `get_posts()` returns `WP_Post` objects rather than the arrays `wp_get_recent_posts()` returns, so
  the loop moved from `$recent['ID']` to `$recent->ID`.

**Please give it a pass on a real install before merging** — particularly the header colours in the
Customizer (both toggle states), the sidebar with widgets removed while logged out, and a single post
with the share buttons.
