### PR TITLE
Record how to lint PHP without installing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,15 @@ are all core's job. Duplicating them is worse than omitting them.
 
 There is no test suite and no CI, so verification is manual. Say in the PR what you actually checked.
 
+- **PHP lint, before anything else.** No PHP is installed on the machine this is usually written
+  on, which is not a reason to skip the check. Download a portable build — the `nts-Win32-x64` zip
+  from <https://windows.php.net/downloads/releases/> — extract it to a scratch directory and run
+  `php -l` over every `.php` file from there. No install, nothing on `PATH`, delete it afterwards.
+  Lint against both the oldest and the newest PHP the theme header claims to support.
+- **Output-changing code deserves more than a lint.** Stub the WordPress functions a change calls,
+  copy the real implementations of the two or three that actually matter out of core, and assert on
+  what the function prints. That is how the share-URL encoding was verified — and how a regression
+  in it was caught, by running the same assertions against the previous commit.
 - **Front end:** home, a single post with comments, a category archive, a search result (including
   one with no results), a page, and a 404.
 - **PHP notices:** run with `WP_DEBUG` on and confirm the change adds none.


### PR DESCRIPTION
Two lines in `AGENTS.md`'s **Verifying a change** section.

The guide said verification is manual and stopped there, so both #21 and the first two commits of #22 shipped on "checked by reading" — the stated reason being that no PHP was installed. That turned out to be a two-minute problem: a portable `nts-Win32-x64` zip extracted into a scratch directory runs `php -l` with nothing installed and nothing on `PATH`.

The second bullet records the stub-and-assert approach, because a lint alone would not have caught the share-URL encoding regression in #22 — that needed the real `add_query_arg()` from core and an assertion on the output. Running the same assertions against the previous commit is what proved the regression was real rather than theoretical.

Both belong in the guide rather than in a prompt, so they survive a new session.

No code changes. #23 remains the permanent fix — once CI runs `php -l`, the first bullet becomes a description of what the pipeline already does.