### PR TITLE
Fix the M2 correctness bugs (#5, #6, #7, #8, #9)

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -34,7 +34,7 @@
 		</header>
 
 		<?php while ( have_posts() ) : the_post(); ?>
-			<article class="post" id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<article id="post-<?php the_ID(); ?>" <?php post_class( 'post' ); ?>>
 				<?php get_template_part( 'template-parts/post-meta' ); ?>
 				<div class="entry">
 					<div class="post-title">

--- a/functions.php
+++ b/functions.php
@@ -431,6 +431,23 @@ function abdeljalil_social_sharing_buttons() {
 }
 
 /***************************************************************
+ * SEO Helpers
+ **************************************************************/
+/**
+ * Reduce post content or an excerpt to plain text fit for a meta description.
+ *
+ * strip_tags() alone leaves shortcodes and block delimiters behind, so a post
+ * opening with [gallery] or any plugin shortcode gets that literal text as its
+ * description and its schema description.
+ *
+ * @param string $text Raw post content or excerpt.
+ * @return string Plain text, no markup, no shortcodes, no block delimiters.
+ */
+function almothafar_plain_text_summary( $text ) {
+	return wp_strip_all_tags( strip_shortcodes( excerpt_remove_blocks( $text ) ) );
+}
+
+/***************************************************************
  * Meta Description
  **************************************************************/
 function almothafar_add_meta_description() {
@@ -445,7 +462,7 @@ function almothafar_add_meta_description() {
 				$description = get_the_excerpt( $post );
 			} else {
 				// Generate from content
-				$description = wp_trim_words( strip_tags( $post->post_content ), 30, '...' );
+				$description = wp_trim_words( almothafar_plain_text_summary( $post->post_content ), 30, '...' );
 			}
 		}
 	} elseif ( is_category() ) {
@@ -477,7 +494,7 @@ function almothafar_add_meta_description() {
 
 	// Clean and output
 	if ( $description ) {
-		$description = wp_strip_all_tags( $description );
+		$description = almothafar_plain_text_summary( $description );
 		$description = str_replace( array( "\r", "\n", "\t" ), ' ', $description );
 		$description = trim( preg_replace( '/\s+/', ' ', $description ) );
 		echo '<meta name="description" content="' . esc_attr( $description ) . '" />' . "\n";
@@ -490,15 +507,18 @@ add_action( 'wp_head', 'almothafar_add_meta_description', 1 );
  **************************************************************/
 function almothafar_add_structured_data() {
 	if ( is_singular( 'post' ) ) {
+		// No setup_postdata() here: on a singular request the main query has already
+		// set the loop up before wp_head fires, so the call achieves nothing.
 		global $post;
-		setup_postdata( $post );
 
 		$author_id = $post->post_author;
 		$schema = array(
 			'@context'      => 'https://schema.org',
 			'@type'         => 'Article',
 			'headline'      => get_the_title(),
-			'description'   => has_excerpt() ? get_the_excerpt() : wp_trim_words( strip_tags( $post->post_content ), 30 ),
+			'description'   => has_excerpt()
+				? almothafar_plain_text_summary( get_the_excerpt() )
+				: wp_trim_words( almothafar_plain_text_summary( $post->post_content ), 30 ),
 			'datePublished' => get_the_date( 'c' ),
 			'dateModified'  => get_the_modified_date( 'c' ),
 			'author'        => array(
@@ -520,16 +540,20 @@ function almothafar_add_structured_data() {
 			),
 		);
 
-		// Add image if available
+		// Add image if available. wp_get_attachment_image_src() returns the URL and
+		// the dimensions of one and the same size, so the two cannot disagree; the
+		// metadata this used to read describes the original upload, not the 'large'
+		// file the URL points at.
 		if ( has_post_thumbnail() ) {
-			$image_url = get_the_post_thumbnail_url( $post->ID, 'large' );
-			$image_meta = wp_get_attachment_metadata( get_post_thumbnail_id( $post->ID ) );
-			$schema['image'] = array(
-				'@type'  => 'ImageObject',
-				'url'    => $image_url,
-				'width'  => isset( $image_meta['width'] ) ? $image_meta['width'] : 1200,
-				'height' => isset( $image_meta['height'] ) ? $image_meta['height'] : 630,
-			);
+			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'large' );
+			if ( $image ) {
+				$schema['image'] = array(
+					'@type'  => 'ImageObject',
+					'url'    => $image[0],
+					'width'  => $image[1],
+					'height' => $image[2],
+				);
+			}
 		}
 
 		// Add article section (category)
@@ -553,7 +577,6 @@ function almothafar_add_structured_data() {
 		echo wp_json_encode( $schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\n";
 		echo '</script>' . "\n";
 
-		wp_reset_postdata();
 	} elseif ( is_front_page() || is_home() ) {
 		// Website schema for homepage
 		$schema = array(
@@ -582,37 +605,54 @@ add_action( 'wp_head', 'almothafar_add_structured_data', 3 );
  **************************************************************/
 function almothafar_add_opengraph_tags() {
 	if ( is_singular() ) {
+		// No setup_postdata() here: on a singular request the main query has
+		// already set the loop up before wp_head fires, so the call achieves
+		// nothing but clobbering $authordata, $page, $pages and $multipage.
 		global $post;
-		setup_postdata( $post );
 
 		$og_title       = get_the_title();
-		$og_description = get_the_excerpt();
+		$og_description = almothafar_plain_text_summary( get_the_excerpt() );
 		$og_url         = get_permalink();
 		$og_image       = '';
+		$og_width       = 0;
+		$og_height      = 0;
 
-		// Get featured image
+		// Featured image, taken at the size that is actually linked so the
+		// dimensions describe the file the URL points at.
 		if ( has_post_thumbnail() ) {
-			$og_image = get_the_post_thumbnail_url( $post->ID, 'large' );
+			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'large' );
+			if ( $image ) {
+				$og_image  = $image[0];
+				$og_width  = $image[1];
+				$og_height = $image[2];
+			}
 		}
 
-		// If no featured image, try to get first image from content
+		// No featured image: the first image in the content. Its real size is
+		// unknown -- it may be remote, or a crop this site never generated -- so
+		// no dimensions are sent. Facebook, LinkedIn and Slack lay the card out
+		// from those numbers and letterbox or crop the image when they are wrong,
+		// which is worse than omitting them and letting the crawler measure it.
 		if ( ! $og_image ) {
-			$content = $post->post_content;
-			preg_match( '/<img[^>]+src=[\'"]([^\'"]+)[\'"][^>]*>/i', $content, $matches );
+			preg_match( '/<img[^>]+src=[\'"]([^\'"]+)[\'"][^>]*>/i', $post->post_content, $matches );
 			if ( isset( $matches[1] ) ) {
 				$og_image = $matches[1];
 			}
 		}
 
-		// Fallback to site logo or default image
+		// Last resort: the site logo, again at a known size.
 		if ( ! $og_image && has_custom_logo() ) {
-			$custom_logo_id = get_theme_mod( 'custom_logo' );
-			$og_image       = wp_get_attachment_image_url( $custom_logo_id, 'full' );
+			$image = wp_get_attachment_image_src( get_theme_mod( 'custom_logo' ), 'full' );
+			if ( $image ) {
+				$og_image  = $image[0];
+				$og_width  = $image[1];
+				$og_height = $image[2];
+			}
 		}
 
 		// Clean up description
-		if ( ! $og_description ) {
-			$og_description = wp_trim_words( strip_tags( $post->post_content ), 30, '...' );
+		if ( '' === $og_description ) {
+			$og_description = wp_trim_words( almothafar_plain_text_summary( $post->post_content ), 30, '...' );
 		}
 
 		echo "\n<!-- Open Graph Meta Tags by Abdeljalil Theme -->\n";
@@ -624,8 +664,11 @@ function almothafar_add_opengraph_tags() {
 
 		if ( $og_image ) {
 			echo '<meta property="og:image" content="' . esc_url( $og_image ) . '" />' . "\n";
-			echo '<meta property="og:image:width" content="1200" />' . "\n";
-			echo '<meta property="og:image:height" content="630" />' . "\n";
+
+			if ( $og_width && $og_height ) {
+				echo '<meta property="og:image:width" content="' . esc_attr( $og_width ) . '" />' . "\n";
+				echo '<meta property="og:image:height" content="' . esc_attr( $og_height ) . '" />' . "\n";
+			}
 		}
 
 		// Twitter Card tags
@@ -638,8 +681,6 @@ function almothafar_add_opengraph_tags() {
 		}
 
 		echo "<!-- / Open Graph Meta Tags -->\n\n";
-
-		wp_reset_postdata();
 	}
 }
 add_action( 'wp_head', 'almothafar_add_opengraph_tags' );

--- a/functions.php
+++ b/functions.php
@@ -753,36 +753,16 @@ if ( ! isset( $content_width ) ) {
 /***************************************************************
  * Custom Comment Template
  **************************************************************/
-/**
- * How many top-level comments precede the page being rendered.
- *
- * WordPress pages comments by top-level comment, and cpage numbers those pages
- * from the oldest regardless of which one "Comments page displayed by default"
- * opens on. Every page before this one therefore holds exactly comments_per_page
- * top-level comments.
- *
- * @return int Number of top-level comments on earlier pages, 0 if not paged.
- */
-function almothafar_comment_page_offset() {
-	if ( ! get_option( 'page_comments' ) ) {
-		return 0;
-	}
-
-	$page     = (int) get_query_var( 'cpage' );
-	$per_page = (int) get_option( 'comments_per_page' );
-
-	if ( $page < 2 || $per_page < 1 ) {
-		return 0;
-	}
-
-	return ( $page - 1 ) * $per_page;
-}
-
 function abdeljalil_comment( $comment, $args, $depth ) {
 	// The number badge counts top-level comments only, continuing across comment
 	// pages. A single counter over every rendered comment numbered the first reply
 	// to comment 1 as comment 2, and restarted from 1 on page 2. Replies carry no
 	// number: they are nested under the comment they answer.
+	//
+	// The page and its size come from $args because wp_list_comments() has already
+	// resolved them -- including the page "Comments page displayed by default"
+	// opens on -- before handing them to the walker, and zeroes both when comment
+	// paging is off, which makes the offset 0 there.
 	//
 	// Assumes the default comment order, oldest first. Switch Discussion settings
 	// to show newer comments at the top of each page and a page's numbers run
@@ -792,8 +772,11 @@ function abdeljalil_comment( $comment, $args, $depth ) {
 	$number = 0;
 
 	if ( 1 === $depth ) {
+		$page     = isset( $args['page'] ) ? (int) $args['page'] : 0;
+		$per_page = isset( $args['per_page'] ) ? (int) $args['per_page'] : 0;
+
 		$top_level_counter++;
-		$number = $top_level_counter + almothafar_comment_page_offset();
+		$number = $top_level_counter + ( ( $page - 1 ) * $per_page );
 	}
 
 	// The badge marks the author of *this post*, not whoever happens to be user 1.

--- a/functions.php
+++ b/functions.php
@@ -731,12 +731,53 @@ if ( ! isset( $content_width ) ) {
 /***************************************************************
  * Custom Comment Template
  **************************************************************/
-function abdeljalil_comment( $comment, $args, $depth ) {
-	static $comment_counter = 0;
-	$comment_counter++;
+/**
+ * How many top-level comments precede the page being rendered.
+ *
+ * WordPress pages comments by top-level comment, and cpage numbers those pages
+ * from the oldest regardless of which one "Comments page displayed by default"
+ * opens on. Every page before this one therefore holds exactly comments_per_page
+ * top-level comments.
+ *
+ * @return int Number of top-level comments on earlier pages, 0 if not paged.
+ */
+function almothafar_comment_page_offset() {
+	if ( ! get_option( 'page_comments' ) ) {
+		return 0;
+	}
 
-	$GLOBALS['comment'] = $comment;
-	$comment_class = ( 1 == $comment->user_id ) ? 'author-comment' : 'comment';
+	$page     = (int) get_query_var( 'cpage' );
+	$per_page = (int) get_option( 'comments_per_page' );
+
+	if ( $page < 2 || $per_page < 1 ) {
+		return 0;
+	}
+
+	return ( $page - 1 ) * $per_page;
+}
+
+function abdeljalil_comment( $comment, $args, $depth ) {
+	// The number badge counts top-level comments only, continuing across comment
+	// pages. A single counter over every rendered comment numbered the first reply
+	// to comment 1 as comment 2, and restarted from 1 on page 2. Replies carry no
+	// number: they are nested under the comment they answer.
+	//
+	// Assumes the default comment order, oldest first. Switch Discussion settings
+	// to show newer comments at the top of each page and a page's numbers run
+	// backwards -- the price of not issuing a second query to count the post's
+	// top-level comments.
+	static $top_level_counter = 0;
+	$number = '';
+
+	if ( 1 === $depth ) {
+		$top_level_counter++;
+		$number = $top_level_counter + almothafar_comment_page_offset();
+	}
+
+	// The badge marks the author of *this post*, not whoever happens to be user 1.
+	$post_author_id = (int) get_post_field( 'post_author', $comment->comment_post_ID );
+	$is_post_author = 0 !== (int) $comment->user_id && (int) $comment->user_id === $post_author_id;
+	$comment_class  = $is_post_author ? 'author-comment' : 'comment';
 	?>
 	<li <?php comment_class( $comment_class ); ?> id="comment-<?php comment_ID(); ?>">
 		<div class="comment-head">
@@ -755,7 +796,9 @@ function abdeljalil_comment( $comment, $args, $depth ) {
 					?>
 				</div>
 			</div>
-			<div class="comment-num"><?php echo esc_html( $comment_counter ); ?></div>
+			<?php if ( '' !== $number ) : ?>
+				<div class="comment-num"><?php echo esc_html( $number ); ?></div>
+			<?php endif; ?>
 		</div>
 		<div class="comment-entry">
 			<?php if ( '0' == $comment->comment_approved ) : ?>

--- a/functions.php
+++ b/functions.php
@@ -855,7 +855,7 @@ function almothafar_fix_akismet_text( $translated, $original, $domain ) {
 	// replacement has to carry the one %s, in the href, and nowhere else.
 	return __(
 		/* translators: %s: URL of the Akismet privacy policy. */
-		'يستخدم هذا الموقع أكيسمت للحد من التعليقات المزعجة. <a href="%s" target="_blank" rel="nofollow noopener">تعرف على كيفية معالجة بيانات تعليقك</a>.',
+		'يستخدم هذا الموقع أكيسمت للحد من التعليقات المزعجة. <a href="%s" target="_blank" rel="nofollow noopener">تعرف على كيفية معالجة بيانات تعليقك.</a>',
 		'abdeljalil'
 	);
 }

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * Modernized for WordPress 6.8+ and PHP 8.4+
  *
  * @package Abdeljalil
- * @version 2.0
+ * @version 2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -454,6 +454,32 @@ function almothafar_plain_text_summary( $text ) {
 	return wp_strip_all_tags( strip_shortcodes( excerpt_remove_blocks( $text ) ) );
 }
 
+/**
+ * A URL and the real dimensions of the file it points at.
+ *
+ * wp_get_attachment_image_src() returns both from one call, so the two always
+ * describe the same file. Attachment metadata does not: it reports the original
+ * upload, which stops being the linked file the moment WordPress generates a
+ * smaller size for it.
+ *
+ * @param int    $attachment_id Attachment to look up.
+ * @param string $size          Registered image size to link.
+ * @return array|false Keys url, width and height, or false if there is no such image.
+ */
+function almothafar_get_sized_image( $attachment_id, $size ) {
+	$image = wp_get_attachment_image_src( $attachment_id, $size );
+
+	if ( ! $image ) {
+		return false;
+	}
+
+	return array(
+		'url'    => $image[0],
+		'width'  => $image[1],
+		'height' => $image[2],
+	);
+}
+
 /***************************************************************
  * Meta Description
  **************************************************************/
@@ -547,18 +573,15 @@ function almothafar_add_structured_data() {
 			),
 		);
 
-		// Add image if available. wp_get_attachment_image_src() returns the URL and
-		// the dimensions of one and the same size, so the two cannot disagree; the
-		// metadata this used to read describes the original upload, not the 'large'
-		// file the URL points at.
+		// Add image if available.
 		if ( has_post_thumbnail() ) {
-			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'large' );
+			$image = almothafar_get_sized_image( get_post_thumbnail_id( $post->ID ), 'large' );
 			if ( $image ) {
 				$schema['image'] = array(
 					'@type'  => 'ImageObject',
-					'url'    => $image[0],
-					'width'  => $image[1],
-					'height' => $image[2],
+					'url'    => $image['url'],
+					'width'  => $image['width'],
+					'height' => $image['height'],
 				);
 			}
 		}
@@ -620,19 +643,12 @@ function almothafar_add_opengraph_tags() {
 		$og_title       = get_the_title();
 		$og_description = almothafar_plain_text_summary( get_the_excerpt() );
 		$og_url         = get_permalink();
-		$og_image       = '';
-		$og_width       = 0;
-		$og_height      = 0;
+		$og_image       = false;
 
 		// Featured image, taken at the size that is actually linked so the
 		// dimensions describe the file the URL points at.
 		if ( has_post_thumbnail() ) {
-			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'large' );
-			if ( $image ) {
-				$og_image  = $image[0];
-				$og_width  = $image[1];
-				$og_height = $image[2];
-			}
+			$og_image = almothafar_get_sized_image( get_post_thumbnail_id( $post->ID ), 'large' );
 		}
 
 		// No featured image: the first image in the content. Its real size is
@@ -643,18 +659,17 @@ function almothafar_add_opengraph_tags() {
 		if ( ! $og_image ) {
 			preg_match( '/<img[^>]+src=[\'"]([^\'"]+)[\'"][^>]*>/i', $post->post_content, $matches );
 			if ( isset( $matches[1] ) ) {
-				$og_image = $matches[1];
+				$og_image = array(
+					'url'    => $matches[1],
+					'width'  => 0,
+					'height' => 0,
+				);
 			}
 		}
 
 		// Last resort: the site logo, again at a known size.
 		if ( ! $og_image && has_custom_logo() ) {
-			$image = wp_get_attachment_image_src( get_theme_mod( 'custom_logo' ), 'full' );
-			if ( $image ) {
-				$og_image  = $image[0];
-				$og_width  = $image[1];
-				$og_height = $image[2];
-			}
+			$og_image = almothafar_get_sized_image( get_theme_mod( 'custom_logo' ), 'full' );
 		}
 
 		// Clean up description
@@ -670,11 +685,11 @@ function almothafar_add_opengraph_tags() {
 		echo '<meta property="og:site_name" content="' . esc_attr( get_bloginfo( 'name' ) ) . '" />' . "\n";
 
 		if ( $og_image ) {
-			echo '<meta property="og:image" content="' . esc_url( $og_image ) . '" />' . "\n";
+			echo '<meta property="og:image" content="' . esc_url( $og_image['url'] ) . '" />' . "\n";
 
-			if ( $og_width && $og_height ) {
-				echo '<meta property="og:image:width" content="' . esc_attr( $og_width ) . '" />' . "\n";
-				echo '<meta property="og:image:height" content="' . esc_attr( $og_height ) . '" />' . "\n";
+			if ( $og_image['width'] && $og_image['height'] ) {
+				echo '<meta property="og:image:width" content="' . esc_attr( $og_image['width'] ) . '" />' . "\n";
+				echo '<meta property="og:image:height" content="' . esc_attr( $og_image['height'] ) . '" />' . "\n";
 			}
 		}
 
@@ -684,7 +699,7 @@ function almothafar_add_opengraph_tags() {
 		echo '<meta name="twitter:description" content="' . esc_attr( $og_description ) . '" />' . "\n";
 
 		if ( $og_image ) {
-			echo '<meta name="twitter:image" content="' . esc_url( $og_image ) . '" />' . "\n";
+			echo '<meta name="twitter:image" content="' . esc_url( $og_image['url'] ) . '" />' . "\n";
 		}
 
 		echo "<!-- / Open Graph Meta Tags -->\n\n";
@@ -774,7 +789,7 @@ function abdeljalil_comment( $comment, $args, $depth ) {
 	// backwards -- the price of not issuing a second query to count the post's
 	// top-level comments.
 	static $top_level_counter = 0;
-	$number = '';
+	$number = 0;
 
 	if ( 1 === $depth ) {
 		$top_level_counter++;
@@ -803,7 +818,7 @@ function abdeljalil_comment( $comment, $args, $depth ) {
 					?>
 				</div>
 			</div>
-			<?php if ( '' !== $number ) : ?>
+			<?php if ( $number ) : ?>
 				<div class="comment-num"><?php echo esc_html( $number ); ?></div>
 			<?php endif; ?>
 		</div>
@@ -840,7 +855,7 @@ function abdeljalil_comment( $comment, $args, $depth ) {
 // strings that are not Akismet's. Matching on $original, the untranslated
 // source, rather than substring-replacing $translated, is what keeps it from
 // rewriting unrelated strings that happen to share a word.
-function almothafar_fix_akismet_text( $translated, $original, $domain ) {
+function almothafar_translate_akismet_privacy_notice( $translated, $original, $domain ) {
 	if ( 'akismet' !== $domain ) {
 		return $translated;
 	}
@@ -859,6 +874,6 @@ function almothafar_fix_akismet_text( $translated, $original, $domain ) {
 		'abdeljalil'
 	);
 }
-add_filter( 'gettext', 'almothafar_fix_akismet_text', 20, 3 );
+add_filter( 'gettext', 'almothafar_translate_akismet_privacy_notice', 20, 3 );
 
 // No closing tag: trailing whitespace after it would be sent as output.

--- a/functions.php
+++ b/functions.php
@@ -322,10 +322,17 @@ function abdeljalil_widgets_init() {
 		'name'          => __( 'السايدبار', 'abdeljalil' ),
 		'id'            => 'sidebar-1',
 		'description'   => __( 'Add widgets here to appear in your sidebar.', 'abdeljalil' ),
+		// One element opened, one closed. after_title used to open a .list-content
+		// wrapper that after_widget closed, but WordPress omits both title arguments
+		// when a widget has no title -- the default for several core widgets -- and
+		// the unmatched </div> then closed the sidebar itself, throwing every later
+		// widget out of it. Nothing can wrap only the widget body: there is no hook
+		// that fires after the title and also fires when there is no title. The gap
+		// .list-content provided lives on .widgettitle in style.css instead.
 		'before_widget' => '<div class="%2$s sidebox" id="%1$s">',
-		'after_widget'  => '</div></div>',
+		'after_widget'  => '</div>',
 		'before_title'  => '<div class="widgettitle">',
-		'after_title'   => '</div><div class="list-content">',
+		'after_title'   => '</div>',
 	) );
 }
 add_action( 'widgets_init', 'abdeljalil_widgets_init' );
@@ -336,7 +343,7 @@ add_action( 'widgets_init', 'abdeljalil_widgets_init' );
  **************************************************************/
 function abdeljalil_scripts() {
 	// Enqueue main stylesheet
-	wp_enqueue_style( 'abdeljalil-style', get_stylesheet_uri(), array(), '2.0' );
+	wp_enqueue_style( 'abdeljalil-style', get_stylesheet_uri(), array(), '2.1' );
 
 	// Enqueue Font Awesome for social icons
 	wp_enqueue_style( 'font-awesome', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.3.1/css/all.min.css', array(), '7.3.1' );

--- a/functions.php
+++ b/functions.php
@@ -739,15 +739,34 @@ function abdeljalil_comment( $comment, $args, $depth ) {
 }
 
 /***************************************************************
- * Fix Akismet Privacy Notice - Replace English "processed" with Arabic
+ * Translate the Akismet Comment-Form Privacy Notice
  **************************************************************/
+// Akismet ships no Arabic translation of the privacy notice under the comment
+// form, so it renders in English on an otherwise Arabic page. This supplies one.
+//
+// The filter runs on every translated string on the site, so it bails on the
+// domain first -- one string comparison for the thousands of core and plugin
+// strings that are not Akismet's. Matching on $original, the untranslated
+// source, rather than substring-replacing $translated, is what keeps it from
+// rewriting unrelated strings that happen to share a word.
 function almothafar_fix_akismet_text( $translated, $original, $domain ) {
-	// Fix Akismet's mixed Arabic/English text
-	if ( 'akismet' === $domain || 'default' === $domain ) {
-		// Replace "processed" with Arabic equivalent
-		$translated = str_replace( 'processed', 'تتم معالجتها', $translated );
+	if ( 'akismet' !== $domain ) {
+		return $translated;
 	}
-	return $translated;
+
+	// Matched on the phrase rather than the whole source string: the wording has
+	// been stable across Akismet releases, the link's rel attribute has not.
+	if ( false === strpos( $original, 'Learn how your comment data is processed' ) ) {
+		return $translated;
+	}
+
+	// Akismet sprintf()s its privacy-policy URL into this string, so the
+	// replacement has to carry the one %s, in the href, and nowhere else.
+	return __(
+		/* translators: %s: URL of the Akismet privacy policy. */
+		'يستخدم هذا الموقع أكيسمت للحد من التعليقات المزعجة. <a href="%s" target="_blank" rel="nofollow noopener">تعرف على كيفية معالجة بيانات تعليقك</a>.',
+		'abdeljalil'
+	);
 }
 add_filter( 'gettext', 'almothafar_fix_akismet_text', 20, 3 );
 

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 <main class="site-container">
 	<?php if ( have_posts() ) : ?>
 		<?php while ( have_posts() ) : the_post(); ?>
-			<article class="post" id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<article id="post-<?php the_ID(); ?>" <?php post_class( 'post' ); ?>>
 				<?php get_template_part( 'template-parts/post-meta' ); ?>
 				<div class="entry">
 					<div class="post-title">

--- a/page.php
+++ b/page.php
@@ -3,7 +3,7 @@
 <main class="site-container">
 	<?php if ( have_posts() ) : ?>
 		<?php while ( have_posts() ) : the_post(); ?>
-			<article class="post" id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<article id="post-<?php the_ID(); ?>" <?php post_class( 'post' ); ?>>
 				<div class="entry">
 					<div class="post-title">
 						<h1><?php the_title(); ?></h1>

--- a/search.php
+++ b/search.php
@@ -14,7 +14,7 @@
 		</header>
 
 		<?php while ( have_posts() ) : the_post(); ?>
-			<article class="post" id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<article id="post-<?php the_ID(); ?>" <?php post_class( 'post' ); ?>>
 				<?php get_template_part( 'template-parts/post-meta' ); ?>
 				<div class="entry">
 					<div class="post-title">

--- a/sidebar.php
+++ b/sidebar.php
@@ -13,19 +13,17 @@ if ( ! is_active_sidebar( 'sidebar-1' ) && ! current_user_can( 'edit_theme_optio
 		<?php // Setup hint for editors only; it names an admin URL and is of no use to visitors. ?>
 		<div class="sidebox">
 			<div class="widgettitle"><?php esc_html_e( 'القائمة الجانبية', 'abdeljalil' ); ?></div>
-			<div class="list-content">
-				<p>
-					<?php
-					printf(
-						/* translators: %s: link to the Widgets admin screen. */
-						esc_html__( 'لإضافة مربعات القائمة الجانبية، توجه إلى %s، ثم اسحب المربعات إلى "السايدبار".', 'abdeljalil' ),
-						'<a href="' . esc_url( admin_url( 'widgets.php' ) ) . '">'
-							. esc_html__( 'المظهر > مربعات القائمة الجانبية', 'abdeljalil' )
-							. '</a>'
-					);
-					?>
-				</p>
-			</div>
+			<p>
+				<?php
+				printf(
+					/* translators: %s: link to the Widgets admin screen. */
+					esc_html__( 'لإضافة مربعات القائمة الجانبية، توجه إلى %s، ثم اسحب المربعات إلى "السايدبار".', 'abdeljalil' ),
+					'<a href="' . esc_url( admin_url( 'widgets.php' ) ) . '">'
+						. esc_html__( 'المظهر > مربعات القائمة الجانبية', 'abdeljalil' )
+						. '</a>'
+				);
+				?>
+			</p>
 		</div>
 	<?php endif; ?>
 </aside>

--- a/single.php
+++ b/single.php
@@ -3,7 +3,7 @@
 <main class="site-container">
 	<?php if ( have_posts() ) : ?>
 		<?php while ( have_posts() ) : the_post(); ?>
-			<article class="post" id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<article id="post-<?php the_ID(); ?>" <?php post_class( 'post' ); ?>>
 				<?php get_template_part( 'template-parts/post-meta' ); ?>
 				<div class="entry">
 					<div class="post-title">

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Abdeljalil Theme
 Theme URI: https://github.com/almothafar/abdeljalil-theme
 Description: A modernized Arabic RTL WordPress theme with responsive design, HTML5 semantics, and enhanced security. Originally created by Abdeljalil, now maintained and modernized by Al-Mothafar Al-Hasan. Fully compatible with WordPress 6.8+ and PHP 8.4+.
-Version: 2.0
+Version: 2.1
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.4
@@ -1328,10 +1328,6 @@ img.avatar {
 	padding: 0;
 }
 
-.list-content {
-	padding-block-start: var(--spacing-sm);
-}
-
 .sidebox {
 	background-color: var(--color-bg-gray-alt);
 	border: 1px solid var(--color-border);
@@ -1398,6 +1394,14 @@ img.avatar {
 	font-weight: bold;
 	border-block-end: 1px solid var(--color-border);
 	padding-block-end: 7px;
+	/* The gap below the rule that .list-content used to hold. */
+	margin-block-end: var(--spacing-sm);
+}
+
+/* The widget body is a sibling of the title now that nothing wraps it, so its
+   own top margin would collapse with the title's and swallow the gap above. */
+.widgettitle + * {
+	margin-block-start: 0;
 }
 
 


### PR DESCRIPTION
Milestone **M2 — Correctness**, five issues, one commit each. Branched from `main` at `d681ab4`, after the M1 pass.

| Commit | Issue | What it fixes |
| --- | --- | --- |
| `4bf30aa` | #7 | The `gettext` filter rewrote every translated string on the site |
| `ce41e5d` | #9 | og:image dimensions, shortcodes in descriptions, needless `setup_postdata()` |
| `de63aa4` | #8 | Comment author badge, numbering, legacy global |
| `93c8f70` | #6 | Sidebar widget wrapper opened one `<div>` and closed two |
| `2386281` | #5 | `post_class()` output discarded by a duplicate `class` attribute |
| `09017ea` | #7 | Follow-up: match Akismet's own full-stop placement, checked against the plugin source |
| `34e3068` | — | Code-review follow-up: extract the image helper, drop a two-type sentinel, rename the Akismet filter |
| `8b6a47a` | — | Code-review follow-up: take the comment page offset from `$args` rather than re-deriving it |

## Files changed, and what a hand deploy needs

Eight files. Six of them change what the running site does; the other two changes are the version bump's paperwork and are still required, because the version is what busts the stylesheet cache.

**Affects the running site — copy these:**

- `functions.php` — all five issues touch it. This is the whole of #7, #9 and #8, plus the sidebar registration for #6 and the enqueue version.
- `style.css` — #6 only: `.list-content` removed, its gap moved onto `.widgettitle`, and the version header. **Copy this together with `functions.php`, never on its own** — the two carry the same version number, and the widget markup and the widget CSS changed in the same commit.
- `sidebar.php` — #6: the editor-only setup hint drops its hand-written `.list-content`. Only ever seen by a logged-in editor on a site with no widgets.
- `index.php`, `single.php`, `archive.php`, `search.php`, `page.php` — #5, one line each.

**Nothing else.** No new files, no deletions, no changes under `template-parts/`, and none to `header.php`, `footer.php`, `comments.php` or `404.php`.

One absence is worth explaining: #9 names `404.php:54` as carrying the same cargo-cult `wp_reset_postdata()`. It does not any more — that one went in the M1 pass, before this branch was cut at `d681ab4`. All three of #9's sub-problems are addressed; the third simply had nothing left to do.

After copying, hard-refresh once. The stylesheet URL is unchanged (`get_stylesheet_uri()`) and only its `?ver=` moves 2.0 → 2.1, so a browser holding 2.0 picks the new one up on its own; the hard refresh is only to see it immediately.

## The three calls worth arguing about

### #5 lands here, not with #14 and #16

#5's note says the cheapest path is to do the `template-parts/content.php` extraction (#16) and fix the heading levels (#14) in the same pass, since all three touch the same lines.

Landing it standalone instead. #5 is the only `severity:critical` bug in M2; #14 is M4 and #16 is M5, so folding it in would pull two later milestones into a correctness PR and turn a five-line diff into a template extraction. Both issues already sanction this — #5 says "if this needs to ship sooner, land it standalone and rebase the refactor onto it", and #16 says to rebase onto #5 rather than revert if it has already shipped. The extraction still collapses these five lines into one when it lands; it just collapses a correct line instead of a broken one.

It also matters for how this gets deployed. Five one-line changes are something you can eyeball against the live site after copying files by hand. A template extraction is not.

**Five templates, not four.** `page.php:6` carries the identical line and the identical bug — the audit's affected list missed it. Fixed there too, rather than leaving one instance of a critical bug in place because an issue's file list was short.

### #9: the prescribed mechanism was replaced

#9 says of the og:image dimensions: *"`almothafar_add_structured_data()` two blocks earlier already reads real dimensions via `wp_get_attachment_metadata()`. **Reuse that**."*

Did not reuse it — deleted it. The issue holds up that call as the good example, but it is subtly wrong in the same way it is complaining about: `wp_get_attachment_metadata()` reports the dimensions of the *original upload*, while the URL beside it points at the `large` file. A 4032×3024 photo was being described as 4032 wide next to a link to the 1024-wide version. `wp_get_attachment_image_src()` returns the URL and the dimensions of one and the same size from a single call, so the two cannot drift. Both the Open Graph function and the JSON-LD block use it, via `almothafar_get_sized_image()`.

So #9's three sub-problems are all fixed, but the first one is fixed better than it asked for, and a bug it did not spot goes with it.

### #6: `.list-content` is deleted rather than moved

The issue offers two ways out: move `.list-content` into `before_widget` so it is always opened, or drop it and style the widget body with a child selector.

Dropped it. The wrapper's entire job was `padding-block-start: var(--spacing-sm)` — the gap between a widget's title and its body. Opening it in `before_widget` would put the title *inside* an element named for the content, and would move that padding above the title rather than between the two, so the CSS had to change either way.

The deeper reason is that no arrangement of these four arguments can wrap only the widget body. WordPress offers no hook that fires after the title *and* fires when there is no title. So the wrapper cannot be made to mean what its name says — and an element that only sometimes exists is precisely what caused the bug. Deleting it removes the failure mode instead of patching around it, and ships one fewer `div` per widget.

The gap is now `margin-block-end` on `.widgettitle`, which renders the same: 10px below the rule when there is a title, nothing when there is not. `.widgettitle + *` zeroes the first body element's top margin, because that margin and the title's are now adjacent siblings and would otherwise collapse into whichever is larger — without it, a widget whose body opens with a `<p>` would lose the 10px to the paragraph's own margin.

Strictly this is neither of the two options as written: the issue's second one says *"style the widget body with a child selector on `.sidebox`"*, and an **adjacent-sibling** selector on `.widgettitle` is what the markup actually allows. A child selector on `.sidebox` would have to name every element a widget might open with; `.widgettitle + *` names the one position the gap belongs to.

**One consequence worth flagging:** any custom CSS keyed to `.list-content` — in the Customizer's Additional CSS, a child theme, or a plugin — silently loses its hook. Nothing in the theme referenced it apart from the single padding rule now removed, but a live site may.

## How to test

### Lint

No PHP on the machine this was written on, so: portable `nts-Win32-x64` builds from <https://windows.php.net/downloads/releases/> (7.4 comes from `/archives/`), extracted to a scratch directory. Nothing installed, nothing on `PATH`.

```sh
curl -sLO https://windows.php.net/downloads/releases/archives/php-7.4.33-nts-Win32-vc15-x64.zip
curl -sLO https://windows.php.net/downloads/releases/php-8.4.25-nts-Win32-vs17-x64.zip
unzip -q php-7.4.33-nts-Win32-vc15-x64.zip -d php74
unzip -q php-8.4.25-nts-Win32-vs17-x64.zip -d php84

for v in php74 php84; do
  for f in $(find . -name '*.php' -not -path './.git/*'); do ./$v/php.exe -l "$f"; done
done
```

7.4.33 and 8.4.25 are the oldest and newest the `style.css` header claims (`Requires PHP: 7.4`, and PHP 8.4 in the description). Both clean, on every `.php` file in the theme.

### Behaviour

A lint only proves it parses, so each output-changing commit got a harness that stubs the WordPress API around the function and asserts on what it prints. The handful of core functions that actually matter are copied out of core rather than faked: `post_class()`, `get_shortcode_regex()`, `strip_shortcodes()`, `wp_strip_all_tags()`, `wp_trim_words()`.

The harnesses are not in the repo — there is nowhere for them to live until #23 lands CI. They are reproducible from the descriptions below, and the important number is the last column: each set was run against the commit *before* its fix, and each one fails there. A harness that passes on both commits is not testing anything.

**84 assertions, all passing, no notices at `E_ALL`.**

| | What it drives | Assertions | Failing before the fix |
| --- | --- | --- | --- |
| #7 | The `gettext` filter, with a recursive `apply_filters` stand-in so the `__()` call inside it is exercised | 10 | 3 — core strings containing "processed" get rewritten into mixed English/Arabic |
| #9 | `almothafar_add_opengraph_tags()`, `almothafar_add_meta_description()` and `almothafar_add_structured_data()`, capturing their `wp_head` output | 15 | 11 — hardcoded 1200×630, shortcode text in descriptions, postdata calls |
| #8 | `abdeljalil_comment()` driven the way `Walker_Comment` does it — depth starting at 1, the global set by the caller, `page`/`per_page` in `$args` as `wp_list_comments()` resolves them | 8 | 4, plus 1 error — user 1 badged, replies numbered in the top-level sequence, paging ignored |
| #6 | `dynamic_sidebar()`'s wrapper behaviour: the widget wrapper always, the title wrapper only for a non-empty title | 6 | 4 — a titleless widget closes one `div` more than it opens |
| #5 | Each template's `<article>` line against core's real `post_class()`, parsing the class attributes back out the way a browser would | 45 | every template emits two `class` attributes |

Worth spelling out for a few of them, since the fixture is the whole point:

- **#7** asserts the Akismet notice is replaced and still carries exactly one `%s` that survives `sprintf()`, and that three core strings containing "processed" (`%s item processed.`, `Your order is being processed.`, `The file has been processed and imported.`), a WooCommerce-domain string, and a non-notice Akismet string all come back untouched. The notice fixture is copied verbatim from `akismet/class.akismet.php:2288`.
- **#9** runs five image cases — featured image, content-scraped image, custom logo, no image, and a featured image whose original upload is larger than the `large` file — plus a `[gallery]` fixture and a block-delimiter fixture, and records whether `setup_postdata()` is called at all.
- **#6** counts `div` nesting across a titled widget, a titleless one, and a sidebar mixing the two, and fails if a close ever outruns the opens.
- **#8** uses a three-comment fixture for the badge (user 1 who did not write the post, the post's actual author, a logged-out visitor), a six-comment two-level tree for the numbering, a page-3-of-5 fixture for the offset, and a paging-off fixture plus a call with no page args at all — the two cases the offset arithmetic could go negative or notice-error in.

### On a real install

Not done — see below. When someone does have one in front of them, the pass that matters for this PR:

1. **A single post with comments** (#8, #9): the "author" badge should sit on comments by *this post's* author, not user 1. Threaded replies carry no number and top-level comments run 1, 2, 3. With comment paging on, page 2 continues rather than restarting. View source: `og:image:width` / `og:image:height` should match the real featured image, and both should be absent when the post has no featured image but does have an inline `<img>`.
2. **A post whose content opens with `[gallery]` or any shortcode** (#9): the `<meta name="description">` and the JSON-LD `description` should start at the first real sentence, with no `[` in either.
3. **The sidebar with a titleless widget** (#6) — Meta and Search default to no title. Add one, put another widget after it, and confirm the second is still inside the `aside`. This is the one that needs the 600px RTL check too.
4. **Any archive, and a single post** (#5): view source on `<article>`. One `class` attribute, carrying `post` plus `post-123 type-post status-publish category-* tag-*`. A sticky post on the home page should have `sticky` in there.
5. **`WP_DEBUG` on** for all of the above.
6. **wp-admin** (#7): bulk-delete some posts, run an import, or open the media library, and confirm nothing renders as mixed English/Arabic. That is the regression the old filter caused and the reason this one bails on the domain first.

There is a standalone preview page in the scratchpad at `sidebar-preview.html` — the real `style.css` inlined, four widgets, two of them with no title and two whose body opens with a `<p>`. Opening it and narrowing past 600px covers step 3 without an install. If no `.sidebox` escapes the `aside`, #6 is right.

## What was not verified

**No browser, and no WordPress install.** So:

- The `style.css` change in #6 is reasoned from the cascade, not seen. **The 600px RTL breakpoint has not been looked at.** The breakpoint rules for the sidebar (`style.css:1589-1607`) set `flex`, `width`, `max-width` and `margin` on `.site-sidebar`, and touch neither `.widgettitle` nor anything inside a widget, so the change should not interact with them — but that is an argument, not an observation, and it is the one thing here that wants a human eye.
- Steps 1 to 6 above were not run. `E_ALL` being clean in the harness is not the same as `WP_DEBUG` being clean on a real install.

## Noted, not done here

**The Akismet filter should eventually go away entirely — #28.** Checking the plugin source turned up the real story: Akismet's Arabic translation is not missing, it is *wrong*. The published language pack ships `...بيانات التعليقات الخاصة بك processed</a>` — the last word of the link text was never translated. So the theme has been patching a defective upstream string at runtime, for a notice that is off by default (`akismet_comment_form_privacy_notice` defaults to `hide`), with a filter that fires on every translated string in every request. The fix belongs at translate.wordpress.org, after which the filter comes out of `functions.php` altogether. Left in place here because #7 asked for the filter to be fixed, not removed, and the fixed version costs one string comparison; #28 carries the removal.

- **#7's optional `! is_admin()` gate was not taken.** The issue says *"Consider also gating on `! is_admin()` if the notice only appears on the front end."* It does — Akismet hooks it on `comment_form_after` — but the domain bail already costs one string comparison and excludes every admin request at the same price, so a second condition would buy nothing. Considered and declined rather than missed.
- **Two changes in the Open Graph function that no issue asked for.** `if ( ! $og_description )` became `if ( '' === $og_description )` for the Yoda/strict-comparison standard, and the single-use `$content = $post->post_content` was inlined into the `preg_match()` call. Both are incidental to rewriting the function; neither changes behaviour.
- `abdeljalil_comment()`'s numbering assumes the default comment order, oldest first. A site set to show newer comments at the top of each page gets each page's numbers running backwards. Fixing that means a second query to count the post's top-level comments, which is not worth it for a non-default setting. Said in the code as well as here.
- `abdeljalil_comment()` still holds six hard-coded Arabic strings. Not touched — they are not lines this PR rewrites, and there is no i18n issue open to land them under.

Closes #5, closes #6, closes #7, closes #8, closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
