### PR TITLE
Correct the version headers and drop the dead html5 arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,11 +52,7 @@ are all core's job. Duplicating them is worse than omitting them.
 
 There is no test suite and no CI, so verification is manual. Say in the PR what you actually checked.
 
-- **PHP lint, before anything else.** No PHP is installed on the machine this is usually written
-  on, which is not a reason to skip the check. Download a portable build — the `nts-Win32-x64` zip
-  from <https://windows.php.net/downloads/releases/> — extract it to a scratch directory and run
-  `php -l` over every `.php` file from there. No install, nothing on `PATH`, delete it afterwards.
-  Lint against both the oldest and the newest PHP the theme header claims to support.
+- **PHP lint, before anything else.** No PHP is installed on the machine this is usually written on, which is not a reason to skip the check. Download a portable build — the `nts-Win32-x64` zip from <https://downloads.php.net/~windows/releases/>, which is where <https://windows.php.net/downloads/releases/> now redirects, so `curl` needs `-L` — extract it to a scratch directory and run `php -l` over every `.php` file from there. No install, nothing on `PATH`, delete it afterwards. That index carries one build per branch, and the compiler tag differs between them: `vc15` for 7.4, `vs16` for 8.0 to 8.3, `vs17` for 8.4 and up. Lint against both the oldest and the newest PHP the theme header claims to support; the oldest is on that live index, not in `archives/`.
 - **Output-changing code deserves more than a lint.** Stub the WordPress functions a change calls,
   copy the real implementations of the two or three that actually matter out of core, and assert on
   what the function prints. That is how the share-URL encoding was verified — and how a regression

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A modernized Arabic RTL WordPress theme with responsive design, HTML5 semantics, and enhanced security.
 
 ![Version](https://img.shields.io/badge/version-2.0-blue.svg)
-![WordPress](https://img.shields.io/badge/WordPress-6.8%2B-21759b.svg)
+![WordPress](https://img.shields.io/badge/WordPress-5.7%2B-21759b.svg)
 ![PHP](https://img.shields.io/badge/PHP-7.4%2B-777bb4.svg)
 ![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)
 ![RTL](https://img.shields.io/badge/RTL-yes-success.svg)
@@ -21,8 +21,8 @@ The theme has been rebuilt from the ground up to meet modern WordPress and web s
 - ✅ **Fully Responsive** - Mobile-first design with comprehensive breakpoints
 - ✅ **HTML5 Semantic Markup** - Modern, accessible code
 - ✅ **Security Hardened** - Removed malware, added input sanitization
-- ✅ **WordPress 6.8+ Compatible** - Uses latest WordPress APIs
-- ✅ **PHP 8.4+ Compatible** - No deprecated functions
+- ✅ **WordPress 5.7+ Compatible** - Uses current WordPress APIs
+- ✅ **PHP 7.4+ Compatible** - No deprecated functions
 - ✅ **Modern Social Sharing** - Facebook, X, LinkedIn, Telegram, WhatsApp
 - ✅ **Customizable Social Media Links** - Add your social profiles via Theme Customizer
 - ✅ **Social Icons in Header** - Display GitHub, LinkedIn, X, Facebook, Steam icons
@@ -92,6 +92,13 @@ The theme has been rebuilt from the ground up to meet modern WordPress and web s
 ## 🛠️ Changelog
 
 ### Unreleased
+**Correct the version headers and drop the dead html5 arguments**
+
+- `Requires at least` moves from 5.0 to 5.7, re-derived from what the theme actually calls. The newest core APIs in it are the `wp_robots` filter and `wp_robots_no_robots()`, both 5.7.0. Below that the theme did not fatal -- the filter simply never fired, so author, date and search archives quietly stopped being de-indexed.
+- The requirements are now declared in one place, the `style.css` theme header. The `functions.php` docblock and the theme description used to restate them, and had drifted to claiming "WordPress 6.8+ and PHP 8.4+", which contradicted the headers three lines below.
+- Dropped the `html5` feature's `style` and `script` arguments, which WordPress 7.0 deprecated and ignores. On 5.7 to 6.9 this puts a redundant `type='text/css'` back on the stylesheet link, and on 5.7 to 6.3 a `type='text/javascript'` on the comment-reply script; both are valid HTML5 and nothing behaves differently.
+- Theme version 2.1 to 2.2. The previous release changed `style.css` without moving the version, so caches still holding 2.1 were rendering the new inline SVG icons unsized.
+
 **Drop the Font Awesome CDN and inline the nine icons as SVG**
 
 - Removed the Font Awesome stylesheet that was loaded from cdnjs on every page. It cost 325,244 bytes across three render-blocking cross-origin requests -- a 90 KB stylesheet and two complete icon fonts -- and disclosed every visitor's IP address to Cloudflare, to draw nine pictures. The theme now makes no third-party requests at all.

--- a/functions.php
+++ b/functions.php
@@ -2,7 +2,7 @@
 /**
  * Abdeljalil Theme Functions
  *
- * Requires WordPress 5.7 or later and PHP 7.4 or later
+ * Requirements are declared once, in the style.css theme header.
  *
  * @package Abdeljalil
  * @version 2.2
@@ -821,7 +821,7 @@ add_action( 'wp_head', 'almothafar_add_opengraph_tags' );
 // collects rather than printing a second, competing tag.
 //
 // This filter and wp_robots_no_robots() are the newest core APIs the theme
-// calls, so they are what set Requires at least: 5.7 in style.css.
+// calls, so they are what set the Requires at least header in style.css.
 //
 // wp_robots_no_robots() is core's own helper for this case: it sets noindex
 // and pairs it with follow or nofollow according to blog_public. Setting

--- a/functions.php
+++ b/functions.php
@@ -2,10 +2,10 @@
 /**
  * Abdeljalil Theme Functions
  *
- * Modernized for WordPress 6.8+ and PHP 8.4+
+ * Requires WordPress 5.7 or later and PHP 7.4 or later
  *
  * @package Abdeljalil
- * @version 2.1
+ * @version 2.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -48,8 +48,6 @@ function abdeljalil_theme_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
-		'style',
-		'script',
 	) );
 
 	// Add theme support for title tag
@@ -343,7 +341,7 @@ add_action( 'widgets_init', 'abdeljalil_widgets_init' );
  **************************************************************/
 function abdeljalil_scripts() {
 	// Enqueue main stylesheet
-	wp_enqueue_style( 'abdeljalil-style', get_stylesheet_uri(), array(), '2.1' );
+	wp_enqueue_style( 'abdeljalil-style', get_stylesheet_uri(), array(), '2.2' );
 
 	// Enqueue comment reply script
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
@@ -821,6 +819,9 @@ add_action( 'wp_head', 'almothafar_add_opengraph_tags' );
 // Core has emitted the robots meta tag through wp_robots() -- hooked to
 // wp_head at priority 1 -- since WordPress 5.7. Add to the directives it
 // collects rather than printing a second, competing tag.
+//
+// This filter and wp_robots_no_robots() are the newest core APIs the theme
+// calls, so they are what set Requires at least: 5.7 in style.css.
 //
 // wp_robots_no_robots() is core's own helper for this case: it sets noindex
 // and pairs it with follow or nofollow according to blog_public. Setting

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Abdeljalil Theme
 Theme URI: https://github.com/almothafar/abdeljalil-theme
-Description: A modernized Arabic RTL WordPress theme with responsive design, HTML5 semantics, and enhanced security. Originally created by Abdeljalil, now maintained and modernized by Al-Mothafar Al-Hasan. Runs on WordPress 5.7 or later and PHP 7.4 or later.
+Description: A modernized Arabic RTL WordPress theme with responsive design, HTML5 semantics, and enhanced security. Originally created by Abdeljalil, now maintained and modernized by Al-Mothafar Al-Hasan.
 Version: 2.2
 Requires at least: 5.7
 Tested up to: 6.8

--- a/style.css
+++ b/style.css
@@ -1,9 +1,9 @@
 /*
 Theme Name: Abdeljalil Theme
 Theme URI: https://github.com/almothafar/abdeljalil-theme
-Description: A modernized Arabic RTL WordPress theme with responsive design, HTML5 semantics, and enhanced security. Originally created by Abdeljalil, now maintained and modernized by Al-Mothafar Al-Hasan. Fully compatible with WordPress 6.8+ and PHP 8.4+.
-Version: 2.1
-Requires at least: 5.0
+Description: A modernized Arabic RTL WordPress theme with responsive design, HTML5 semantics, and enhanced security. Originally created by Abdeljalil, now maintained and modernized by Al-Mothafar Al-Hasan. Runs on WordPress 5.7 or later and PHP 7.4 or later.
+Version: 2.2
+Requires at least: 5.7
 Tested up to: 6.8
 Requires PHP: 7.4
 Author: Al-Mothafar Al-Hasan


### PR DESCRIPTION
Closes #13

## What this changes

`Requires at least: 5.0` was the wrong number in the direction that actually breaks: the theme calls core APIs that did not exist in 5.0. The issue argued for 5.5 from `wp_body_open()` and "the sitemap filters", but #25 deleted those filters, and in the same pass added an `add_filter( 'wp_robots', ... )` callback that returns `wp_robots_no_robots( $robots )`. Both are 5.7.0 ([`wp_robots`](https://developer.wordpress.org/reference/hooks/wp_robots/), [`wp_robots_no_robots()`](https://developer.wordpress.org/reference/functions/wp_robots_no_robots/)), so the floor is **5.7**, not 5.5. Nothing else in the theme reaches higher: every core call across all 17 PHP files was enumerated and diffed against real 5.6 and 5.7 trees — everything the theme calls exists in 5.7, and exactly `wp_robots`, `wp_robots_no_robots` and `wp_robots_noindex_search` are missing from 5.6. Runners-up are `wp_date()` (5.3), `wp_body_open()` (5.2) and the `responsive-embeds` theme support (5.0). No `get_template_part()` or `get_search_form()` call passes the `$args` parameter that would have pulled in 5.5 on its own.

`Requires PHP: 7.4` stays — it is core's own minimum for 7.1, per `api.wordpress.org/core/version-check/1.7/`. What had to give was everything else claiming otherwise. Both floors were being restated in four places across two files, and only the `style.css` headers are read by anything; the copies had already drifted to "WordPress 6.8+ and PHP 8.4+" in the `functions.php` docblock and the theme `Description:`, contradicting the headers three lines below them. The headers are now the only statement of it. The docblock points at them, the description no longer mentions versions, and the comment by the `wp_robots` filter names the header instead of repeating its value — so there is nothing left to drift. `README.md` carried the same contradiction in a badge and two feature bullets and is corrected to match; its Version 2.0 changelog section keeps the old wording, because that is a record of what that release claimed rather than a claim about today.

The `html5` feature's `'script'` and `'style'` arguments are deprecated and unused as of 7.0.0, so they are gone.

Version **2.1 to 2.2**, in `style.css` and in the `wp_enqueue_style( 'abdeljalil-style', ... )` argument together. This is not housekeeping: #11 (PR #29) rewrote the icon rules in `style.css` but deliberately held the version at 2.1, so any browser or page cache still holding the old 2.1 stylesheet is rendering the new `<svg class="almothafar-icon">` elements with no sizing rules — an inline SVG with no CSS width falls back to the replaced-element default, roughly 300x150, in the header. This PR is the first thing to touch those files since, so it is the place to close that out.

One change here is not about the theme at all: `AGENTS.md`'s portable-PHP lint recipe points at a URL that now 302s, and a `curl` without `-L` fetches the redirect page, so the lint it prescribes silently never runs. That is a rule that breaks the next person's verification, so it is fixed in the rulebook rather than noted in a PR body nobody rereads. Separate logical change in a PR that is otherwise small, and deliberate.

## Why this way

**`Tested up to:` stays at 6.8, and the deferral is now #31.** The issue wants 7.1 because 6.8 is three majors behind and warns in the installer. AGENTS.md says the line "should track the WordPress version the change was actually verified against; do not raise it speculatively." Those cannot both be satisfied — there is no WordPress install here, and this was not run on 7.1 or on anything else. The rule wins: the installer warning is cosmetic and, more to the point, currently accurate. #31 carries the front-end pass someone with a 7.1 site has to run before the line moves, so the deferral is a tracked issue rather than a paragraph in a merged PR.

**The issue's reason for deleting the two `html5` arguments is not quite right, and it matters here.** It says both "have been inert since [7.0], so removing them changes nothing at runtime." Inert on 7.0+, yes. Below that they are still live, and the theme's floor is 5.7. Reading core: `WP_Scripts` stopped consulting `current_theme_supports( 'html5', 'script' )` in **6.4** — the guard is at `class-wp-scripts.php:173` in 6.3 and absent in 6.4 — and `WP_Styles` still consults `current_theme_supports( 'html5', 'style' )` at `class-wp-styles.php:123` in **6.9**, losing it only in 7.0. So on 5.7 through 6.9 this PR puts `type='text/css'` back on the theme's stylesheet `<link>` and on `wp_add_inline_style()` output, and on 5.7 through 6.3 puts `type='text/javascript'` back on the `comment-reply` script tag. Both attributes are valid HTML5, nothing behaves differently, and a validator's complaint about the script one is a warning rather than an error. Worth stating plainly rather than repeating "changes nothing": the version this theme claims to be tested against, 6.8, is one of the versions where the redundant `type='text/css'` comes back.

I deleted them anyway. They are documented as deprecated in current core, what they buy below 7.0 is one redundant attribute, and carrying dead arguments forever to preserve that is the worse trade. Core emits no deprecation notice for them either, so this is tidying rather than a fix — which is what the ticket asked for.

**The floor is documented where it is set,** as a comment above `almothafar_robots_noindex_thin_pages()`, because the failure below 5.7 is silent rather than fatal. On 5.6 nothing errors: the `wp_robots` filter simply never fires, the callback never runs, and the theme quietly stops de-indexing author archives, date archives and search results. That is worse than a fatal for an SEO feature, and there was nothing in the code to warn someone who lowers the header back down.

## How to test

This change is three header lines, a docblock, two array entries and a version number, so most of it is checked by reading rather than clicking. Each step says what to open and what you should see.

**1. The installer no longer warns about the wrong thing.** On a WordPress 7.1 site, Appearance → Themes → Add New → Upload Theme, and upload this branch as a zip. Before, the theme declared `Requires at least: 5.0`; now it declares 5.7. The install should proceed with no "requires a newer version of WordPress" error. You will still see a note that it has not been tested with your version — that one is deliberate and is issue #31.

**2. It now refuses to install on a version it cannot run.** On a WordPress 5.6 site, upload the same zip. It should be **rejected**, with WordPress naming 5.7 as the requirement. That is the point of the change: on 5.6 the theme installs happily today and then silently stops de-indexing author, date and search archives, because the `wp_robots` filter it uses does not exist there.

**3. The stylesheet is not served stale.** On any post, view source and find the `abdeljalil-style` link. It should read `?ver=2.2`. Then look at the header icons — GitHub, LinkedIn, X — they should be small inline icons, not enormous. If they are roughly 300×150 each, the browser is still holding the 2.1 stylesheet and the version did not move; that is the bug this bump exists to close.

**4. The headers agree with each other.** Open `style.css` and `functions.php` side by side. `Version:` and the `wp_enqueue_style( 'abdeljalil-style', ... )` argument must both say 2.2. Nothing outside the `style.css` header should state a WordPress or PHP requirement any more — the `functions.php` docblock and the theme `Description:` used to, and had drifted to contradicting it.

**5. Nothing about the site changed.** Home, a single post with comments, a category archive, a search with results, a search with none, a page, and a 404. Compare against the previous version: nothing should look or behave differently. With `WP_DEBUG` on, no new notices.

**6. One cosmetic difference is expected, and only below WordPress 7.0.** View source on any post and look at the `abdeljalil-style` `<link>`. On WordPress 6.9 and earlier it now carries `type='text/css'`, which it did not before; on 6.3 and earlier the `comment-reply` script tag likewise regains `type='text/javascript'`. That is the removal of the two `html5` arguments, both attributes are valid HTML5, and nothing behaves differently. On 7.0 and later there is no difference at all.

**7. Lint,** if you are checking the PHP. Portable builds, nothing installed — note the URL in `AGENTS.md` changed in this PR because the old one silently redirects:

    curl -L -O https://downloads.php.net/~windows/releases/php-7.4.33-nts-Win32-vc15-x64.zip
    for f in $(find . -name '*.php' -not -path './.git/*'); do /path/to/php -l "$f"; done

## What I ran

None of the above was done in a browser; no WordPress was involved at all. What follows is what I actually did, so you know which steps have evidence behind them.

PHP lint over all 17 files on 7.4.33, 8.4.25 and 8.5.10 — clean, which covers step 7.

For the `html5` removal I stubbed `add_theme_support()`, `set_post_thumbnail_size()`, `register_default_headers()` and `register_nav_menus()` to record their arguments, called `abdeljalil_theme_setup()`, and diffed the recording against the same run on `main`. The whole diff is the two removed strings; everything else the setup hands to core is identical, which is the real claim — not that the arguments do nothing, but that nothing else moved with them. That covers the "nothing else changed" half of step 5, at the level of what the theme passes to WordPress rather than what a page looks like.

The floor was derived by enumerating every core call across all 17 files and checking each against developer.wordpress.org, and the 6.4 / 6.9 boundary in step 6 by reading `class-wp-scripts.php` and `class-wp-styles.php` at the 6.1 through 7.0 tags. I also intersected every identifier the theme calls with the 250 deprecated function names in WordPress 7.1's `deprecated.php` and `pluggable-deprecated.php`: no hits.

**Steps 1, 2, 3 and 5 have no evidence behind them and need a person with a WordPress site.** Step 3 in particular is the reason the version moved, and nobody has yet confirmed the icons render at the right size after the bump.
## What was not checked

No WordPress install was involved at any point. Nothing here was rendered: not the home page, not a single post, not an archive, not a search result, not a 404. No `WP_DEBUG` run, no view-source, no RTL check at 600px, no editor pass. That is why `Tested up to:` did not move, why #31 exists, and why the 7.1 and 5.6 install checks above are written as instructions rather than as results.

The core-version claims come from `developer.wordpress.org` reference pages and from reading `class-wp-scripts.php` and `class-wp-styles.php` at the 6.1 through 7.0 tags of `WordPress/WordPress`, not from running those versions.

The `style.css` `Tags:` line is untouched and carries three tags that are not on the [allowed list](https://make.wordpress.org/themes/handbook/review/required/theme-tags/): `responsive-layout`, which was removed when the tag list was revamped, and `right-to-left` and `arabic`, which were never on it. It only matters if the theme is ever submitted to the directory, and it is outside what this issue asked for, so it is left alone rather than folded in -- now tracked as #35.

## What to watch when it lands

`style.css` and `functions.php` have to be copied across together — they now both say 2.2, and the agreement is the entire point of the bump. Copy one without the other and the stylesheet either stays cached at 2.1, with the icons unsized at roughly 300x150 in the header, or busts to a `?ver=2.2` URL that serves the old file.

Expect one round of visitors fetching the stylesheet fresh. Depending on the live site's WordPress version, `type='text/css'` will reappear in view-source on the `abdeljalil-style` `<link>` and on the inline header-colour block; that is the `html5 'style'` removal, and it is expected on anything below 7.0.

Land this before **#10**. #10 adds several `add_theme_support()` calls to the same `abdeljalil_theme_setup()` this PR edits, three lines from the ones removed here, and neither ticket carried an overlap note — both now do. This is the small one; #10 should rebase onto it, and the recording harness above is worth re-running there, since #10's whole change to that function is new arguments to the call it stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

