### PR TITLE
Set $content_width to the article column, not the outer container

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -33,12 +33,22 @@ if ( ! defined( 'ALMOTHAFAR_THUMBNAIL_HEIGHT' ) ) {
 	define( 'ALMOTHAFAR_THUMBNAIL_HEIGHT', 400 );
 }
 
-// The outer container, and what $content_width reports to oEmbed -- not the
-// width of the article column. That column is 69% of this, less the 20px
-// padding-inline on .entry, which is the 788px theme.json declares as
-// layout.contentSize. The two numbers describe different boxes.
+// The outer page container -- the max-width .site-wrapper, the site header and
+// the footer share. This is not the number $content_width wants; see
+// ALMOTHAFAR_ARTICLE_WIDTH below. Kept defined because a child theme may
+// already reference it.
 if ( ! defined( 'ALMOTHAFAR_CONTENT_WIDTH' ) ) {
 	define( 'ALMOTHAFAR_CONTENT_WIDTH', 1200 );
+}
+
+// The article column, and what $content_width reports: 69% of the container,
+// less the 20px padding-inline on .entry, which is the 788px theme.json
+// declares as layout.contentSize. Everything core reads $content_width for --
+// the width it requests from an oEmbed provider, and the cap
+// image_constrain_size_for_editor() applies -- is about this box rather than
+// the container. Move this and theme.json's contentSize together.
+if ( ! defined( 'ALMOTHAFAR_ARTICLE_WIDTH' ) ) {
+	define( 'ALMOTHAFAR_ARTICLE_WIDTH', 788 );
 }
 
 /***************************************************************
@@ -940,7 +950,7 @@ add_filter( 'the_generator', 'abdeljalil_remove_version' );
  * Content Width
  **************************************************************/
 if ( ! isset( $content_width ) ) {
-	$content_width = ALMOTHAFAR_CONTENT_WIDTH;
+	$content_width = ALMOTHAFAR_ARTICLE_WIDTH;
 }
 
 


### PR DESCRIPTION
Closes #37

## What this changes

`$content_width` was set to `ALMOTHAFAR_CONTENT_WIDTH`, 1200, which is the max-width of `.site-wrapper` — the outer page container. Everything core reads the global for is about the article column instead: the width it asks an oEmbed provider for, and the cap `image_constrain_size_for_editor()` applies before an image goes into the editor. The article column is 69% of the container less the 20px `padding-inline` on `.entry`, which is 788px, and that is already the number `theme.json` declares as `layout.contentSize`. So the global was being handed the wrong one of the two.

This adds `ALMOTHAFAR_ARTICLE_WIDTH` at 788 and points `$content_width` at it. `ALMOTHAFAR_CONTENT_WIDTH` keeps its value and its name, and the comment on each now says which box it describes and stops explaining the discrepancy away.

## Why this way

The issue offered two constants or one constant plus a derived value. Derived would be `ALMOTHAFAR_CONTENT_WIDTH * 0.69 - 40`, which happens to come out at exactly 788, but it encodes the CSS layout as arithmetic in PHP and would silently drift the moment the sidebar ratio or the `.entry` padding changes — and it would drift away from `theme.json`, which hard-codes 788 and cannot compute anything. Two literal constants means the number appears in the two files that must agree and is greppable in both. The comment says to move it and `theme.json`'s `contentSize` together, since nothing enforces that.

`ALMOTHAFAR_CONTENT_WIDTH` is now read by nothing in the theme. It is left defined rather than removed because it is guarded for a child theme to override, so it may already be referenced somewhere this repo cannot see, and 1200 is still a true statement about a real box.

## How to test

1. Put a YouTube URL on its own line in a new draft and publish it. View source on the post: the `iframe` core requests should now come back with `width="788"` rather than `width="1200"`. On an existing post with an embed, purge the oEmbed cache first (edit and re-save the post) or you will be looking at the response cached under the old width.
2. Open the block editor, insert an image wider than 1024px, and pick the Large size. It should be inserted at 788 wide, not 1024.
3. Open a post whose first image is above the fold — the one core does *not* lazy-load — and read its `sizes` attribute in view-source. It should no longer say `1024px` on an image that occupies 788. Images further down the post carry `sizes="auto, ..."` and were already correct.
4. Load an existing post that already has images and embeds in it and confirm nothing moved. `$content_width` is read at render time, so old posts are affected immediately with no regeneration, but full-size images have never been constrained by it.
5. Home, a category archive, a search result and one with no results, a page, and a 404, with `WP_DEBUG` on: no new notices. Check the single post at a mobile width too, below the 600px breakpoint.

## What I ran

`php -l` over all 17 `.php` files on 7.4.33 and 8.5.10, both clean.

Then a harness, since this changes what core computes rather than what a theme function prints. It copies `image_constrain_size_for_editor()`, `wp_constrain_dimensions()` and `wp_embed_defaults()` verbatim out of WordPress 6.8, stubs the handful of things they call, uses core's own default option values, `require`s the real `functions.php`, and asserts on the results. Against this branch, on both PHP versions, all seven assertions pass:

```
wp_embed_defaults() width x height                            788x1000     ok
image_constrain_size_for_editor( 3000, 2000, 'large' )        788x525      ok
image_constrain_size_for_editor( 1024, 683, 'large' )         788x526      ok
image_constrain_size_for_editor( 3000, 2000, 'medium_large' ) 768x512      ok
image_constrain_size_for_editor( 600, 400, 'large' )          600x400      ok
image_constrain_size_for_editor( 3000, 2000, 'full' )         3000x2000    ok
$content_width matches theme.json contentSize                 788px        ok
```

Against `main`, four of the seven fail, which is what makes them worth having: `wp_embed_defaults()` returns 1200 wide, and a large image is inserted at 1024 — the `large_size_w` default doing the capping, with 1200 constraining nothing, exactly as the issue predicted. The three that pass on both are the controls: `medium_large` is 768 either way, an image narrower than the column is untouched, and `full` is unconstrained, which is why existing posts do not move.

## What was not checked

Not run against a WordPress install, so steps 1 to 5 above are reasoned from core's source and verified against copies of it, not seen in a browser. In particular nobody has watched the Network panel pick a `srcset` candidate, and no real oEmbed request has gone to YouTube — the harness proves what width core would ask for, not what YouTube returns for it.

`wp_calculate_image_sizes()` is not in the harness. It builds `sizes` from the displayed image width rather than from `$content_width`, so the link is one step removed and asserting on it would have meant stubbing image metadata to prove something the first two functions already show.

## What to watch when it lands

`functions.php` alone; no stylesheet change, so nothing to copy alongside it and no cached CSS to worry about. The version headers are untouched for the same reason.

Existing posts change behaviour the moment the file is copied across, with no regeneration step: `$content_width` is read at render time. What that means in practice is a narrower `sizes` on the one non-lazy-loaded image per post, and a smaller width requested for embeds whose oEmbed response is fetched fresh. Embeds already in the `_oembed_` post-meta cache keep their old markup until that entry expires or the post is re-saved, so a wide old embed sitting next to a correct new one for a while is expected, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
