### PR TITLE
Reflow the hard-wrapped Markdown, and carve the licences out of the rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,26 +1,15 @@
 # Copilot instructions — Abdeljalil Theme
 
-A classic (non-block) WordPress theme for an Arabic, right-to-left blog. Plain PHP templates and one
-stylesheet, no build step, no package manager.
+A classic (non-block) WordPress theme for an Arabic, right-to-left blog. Plain PHP templates and one stylesheet, no build step, no package manager.
 
-The full guide is [`AGENTS.md`](../AGENTS.md): coding standards, verification steps, the
-version-bumping rule and the boundaries on what belongs in a theme. Read it. Repeated here are only
-the things most often got wrong in this repo.
+The full guide is [`AGENTS.md`](../AGENTS.md): coding standards, verification steps, the version-bumping rule and the boundaries on what belongs in a theme. Read it. Repeated here are only the things most often got wrong in this repo.
 
-- **Escape at output, with the function that matches the context.** `esc_html()` for text,
-  `esc_attr()` for attributes, `esc_url()` for URLs. `esc_attr()` is not a CSS escaper; hex colours
-  get `sanitize_hex_color()`.
-- **Use CSS logical properties** such as `inset-inline-start` and `margin-block-end`, not
-  `left`/`right`. There is no `rtl.css`; `style.css` is RTL-first.
-- **Every user-facing string goes through the `abdeljalil` text domain**, via `__()`, `_e()` or
-  `esc_html__()`.
-- **Prefix new functions `almothafar_`**, matching the constants and the newer code. `abdeljalil_`
-  is the original 2016 layer; leave those names alone rather than extending them. Note the text
-  domain above is a different thing entirely and never changes.
+- **Escape at output, with the function that matches the context.** `esc_html()` for text, `esc_attr()` for attributes, `esc_url()` for URLs. `esc_attr()` is not a CSS escaper; hex colours get `sanitize_hex_color()`.
+- **Use CSS logical properties** such as `inset-inline-start` and `margin-block-end`, not `left`/`right`. There is no `rtl.css`; `style.css` is RTL-first.
+- **Every user-facing string goes through the `abdeljalil` text domain**, via `__()`, `_e()` or `esc_html__()`.
+- **Prefix new functions `almothafar_`**, matching the constants and the newer code. `abdeljalil_` is the original 2016 layer; leave those names alone rather than extending them. Note the text domain above is a different thing entirely and never changes.
 - **Soft-wrap prose.** One long line per paragraph in Markdown, PR descriptions and commit message bodies. Do not hard-wrap at a column. This does not apply to code or to comments inside code.
 
 <!--
-Why this file exists alongside AGENTS.md: Copilot Chat does not read AGENTS.md in JetBrains, Visual
-Studio, Eclipse or Xcode, and @ file references expand only in Copilot CLI. This path is the one
-instruction file every Copilot surface reads. Keep it short and let AGENTS.md carry the detail.
+Why this file exists alongside AGENTS.md: Copilot Chat does not read AGENTS.md in JetBrains, Visual Studio, Eclipse or Xcode, and @ file references expand only in Copilot CLI. This path is the one instruction file every Copilot surface reads. Keep it short and let AGENTS.md carry the detail.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,67 +1,38 @@
 # Abdeljalil Theme — agent guide
 
-A classic (non-block) WordPress theme for an Arabic, right-to-left blog. Originally by Abdeljalil in
-2016, modernized and maintained by [Al-Mothafar Al-Hasan](https://almothafar.com).
+A classic (non-block) WordPress theme for an Arabic, right-to-left blog. Originally by Abdeljalil in 2016, modernized and maintained by [Al-Mothafar Al-Hasan](https://almothafar.com).
 
-Plain PHP templates and one stylesheet, served exactly as committed. There is no build step and no
-package manager today. If a task genuinely needs one, say so in the PR rather than adding it quietly,
-and commit the output rather than building on demand.
+Plain PHP templates and one stylesheet, served exactly as committed. There is no build step and no package manager today. If a task genuinely needs one, say so in the PR rather than adding it quietly, and commit the output rather than building on demand.
 
-`functions.php` is the one thing worth knowing about the layout: roughly 800 lines holding theme
-setup, the Customizer, enqueues, all SEO output and the comment callback. It is divided into sections
-by `/****...****/` banner comments. Put new code in the section it belongs to, and add a banner if it
-needs a new one.
+`functions.php` is the one thing worth knowing about the layout: roughly 800 lines holding theme setup, the Customizer, enqueues, all SEO output and the comment callback. It is divided into sections by `/****...****/` banner comments. Put new code in the section it belongs to, and add a banner if it needs a new one.
 
 ## Rules
 
-**Escape at output, with the function that matches the context.** `esc_html()` for text,
-`esc_attr()` for attributes, `esc_url()` for URLs, `wp_kses_post()` for markup that may contain
-allowed HTML. Escape at the point of echo, not earlier: an escaped value passed around is a value
-nobody can tell is safe. `esc_attr()` is not a CSS escaper, and hex colours get
-`sanitize_hex_color()`.
+**Escape at output, with the function that matches the context.** `esc_html()` for text, `esc_attr()` for attributes, `esc_url()` for URLs, `wp_kses_post()` for markup that may contain allowed HTML. Escape at the point of echo, not earlier: an escaped value passed around is a value nobody can tell is safe. `esc_attr()` is not a CSS escaper, and hex colours get `sanitize_hex_color()`.
 
-**Every user-facing string goes through the `abdeljalil` text domain**, via `__()`, `_e()`,
-`esc_html__()` or `_n()`. Plenty of hard-coded Arabic predates this rule. Do not add more, and wrap
-what you touch.
+**Every user-facing string goes through the `abdeljalil` text domain**, via `__()`, `_e()`, `esc_html__()` or `_n()`. Plenty of hard-coded Arabic predates this rule. Do not add more, and wrap what you touch.
 
-**Use CSS logical properties** such as `inset-inline-start`, `margin-block-end` and `padding-inline`,
-not `left`/`right`/`margin-left`. There is no `rtl.css`; `style.css` is RTL-first and stays that way.
+**Use CSS logical properties** such as `inset-inline-start`, `margin-block-end` and `padding-inline`, not `left`/`right`/`margin-left`. There is no `rtl.css`; `style.css` is RTL-first and stays that way.
 
-**Follow the WordPress PHP coding standards, as the files already do.** Tabs for indentation. Spaces
-inside parentheses: `function foo( $bar )`. Yoda conditions: `if ( '' === $value )`. Long-form
-`array()`, not `[]`.
+**Follow the WordPress PHP coding standards, as the files already do.** Tabs for indentation. Spaces inside parentheses: `function foo( $bar )`. Yoda conditions: `if ( '' === $value )`. Long-form `array()`, not `[]`.
 
-**Prefix new functions `almothafar_`,** matching the constants (`ALMOTHAFAR_`) and the newer
-code. `abdeljalil_` is the original 2016 layer -- leave those names alone, but do not add
-to them. The `abdeljalil` text domain is unrelated to this and never changes: it is tied to
-the theme slug in `style.css`.
+**Prefix new functions `almothafar_`,** matching the constants (`ALMOTHAFAR_`) and the newer code. `abdeljalil_` is the original 2016 layer -- leave those names alone, but do not add to them. The `abdeljalil` text domain is unrelated to this and never changes: it is tied to the theme slug in `style.css`.
 
-**Do not put plugin behaviour in the theme.** Anything that should survive a theme switch, such as
-disabling XML-RPC, analytics, redirects or custom post types, belongs in a plugin. A user who
-switches themes should not silently lose or regain site behaviour.
+**Do not put plugin behaviour in the theme.** Anything that should survive a theme switch, such as disabling XML-RPC, analytics, redirects or custom post types, belongs in a plugin. A user who switches themes should not silently lose or regain site behaviour.
 
-**No remote assets.** No CDN stylesheets, scripts or fonts. Everything ships from the theme
-directory. Loading from a third party discloses every visitor's IP to that host and cannot be
-audited.
+**No remote assets.** No CDN stylesheets, scripts or fonts. Everything ships from the theme directory. Loading from a third party discloses every visitor's IP to that host and cannot be audited.
 
-**Do not reimplement what core already does.** Before adding output to `wp_head`, check whether
-WordPress emits it already. Canonical URLs, robots directives, sitemaps, feed links and the title tag
-are all core's job. Duplicating them is worse than omitting them.
+**Do not reimplement what core already does.** Before adding output to `wp_head`, check whether WordPress emits it already. Canonical URLs, robots directives, sitemaps, feed links and the title tag are all core's job. Duplicating them is worse than omitting them.
 
 ## Verifying a change
 
 There is no test suite and no CI, so verification is manual. Say in the PR what you actually checked.
 
 - **PHP lint, before anything else.** No PHP is installed on the machine this is usually written on, which is not a reason to skip the check. Download a portable build — the `nts-Win32-x64` zip from <https://downloads.php.net/~windows/releases/>, which is where <https://windows.php.net/downloads/releases/> now redirects, so `curl` needs `-L` — extract it to a scratch directory and run `php -l` over every `.php` file from there. No install, nothing on `PATH`, delete it afterwards. That index carries one build per branch, and the compiler tag differs between them: `vc15` for 7.4, `vs16` for 8.0 to 8.3, `vs17` for 8.4 and up. Lint against both the oldest and the newest PHP the theme header claims to support; the oldest is on that live index, not in `archives/`.
-- **Output-changing code deserves more than a lint.** Stub the WordPress functions a change calls,
-  copy the real implementations of the two or three that actually matter out of core, and assert on
-  what the function prints. That is how the share-URL encoding was verified — and how a regression
-  in it was caught, by running the same assertions against the previous commit.
-- **Front end:** home, a single post with comments, a category archive, a search result (including
-  one with no results), a page, and a 404.
+- **Output-changing code deserves more than a lint.** Stub the WordPress functions a change calls, copy the real implementations of the two or three that actually matter out of core, and assert on what the function prints. That is how the share-URL encoding was verified — and how a regression in it was caught, by running the same assertions against the previous commit.
+- **Front end:** home, a single post with comments, a category archive, a search result (including one with no results), a page, and a 404.
 - **PHP notices:** run with `WP_DEBUG` on and confirm the change adds none.
-- **Markup:** view source rather than trusting that it looks right. This theme has a history of
-  duplicate attributes and unbalanced `div`s that render fine until they do not.
+- **Markup:** view source rather than trusting that it looks right. This theme has a history of duplicate attributes and unbalanced `div`s that render fine until they do not.
 - **RTL:** check at a mobile width too; the layout collapses to one column at 600px.
 - **Editor:** if the change touches enqueues, `theme.json` or editor styles, open the post editor.
 
@@ -72,18 +43,16 @@ The version lives in two places and they must move together:
 - `style.css`, the `Version:` line in the theme header
 - `functions.php`, the version argument passed to `wp_enqueue_style( 'abdeljalil-style', ... )`
 
-If they disagree, browsers serve a stale stylesheet after an update. Bump both in the same commit.
-`Tested up to:` should track the WordPress version the change was actually verified against; do not
-raise it speculatively.
+If they disagree, browsers serve a stale stylesheet after an update. Bump both in the same commit. `Tested up to:` should track the WordPress version the change was actually verified against; do not raise it speculatively.
 
 ## Commits and pull requests
 
-Short imperative subject, no trailing period. Explain why in the body when the reason is not obvious
-from the diff. One logical change per PR, and reference the issue it closes.
+Short imperative subject, no trailing period. Explain why in the body when the reason is not obvious from the diff. One logical change per PR, and reference the issue it closes.
 
-Issues that overlap with another carry a note saying which to land first. Read it before starting, so
-the same lines are not rewritten twice.
+Issues that overlap with another carry a note saying which to land first. Read it before starting, so the same lines are not rewritten twice.
 
 [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) is what GitHub prefills a description with. Write prose under its headings, not a form, and never restate the diff — it asks only for what the diff cannot show: why this approach and not the one you rejected, how someone else can test it, what you did not check, and what to watch for when the files are copied to the live site. Drop a heading you have nothing to say under, and add one where the change calls for it.
 
-**Soft-wrap prose; do not hard-wrap it at a column.** One long line per paragraph in Markdown files, pull request descriptions and commit message bodies, and let the editor or the renderer wrap it. GitHub reflows prose when it renders, so hard-wrapped paragraphs arrive broken at a width that matches nobody's viewport, and changing one word reflows every following line in the diff. List items, table rows and headings stay one per line, as they already are. None of this applies to code or to comments inside code, which follow the WordPress standards above. Most of the Markdown here, this file included, predates the rule and is still wrapped at 100. Do not add more, and reflow what you touch.
+**Soft-wrap prose; do not hard-wrap it at a column.** One long line per paragraph in Markdown files, pull request descriptions and commit message bodies, and let the editor or the renderer wrap it. GitHub reflows prose when it renders, so hard-wrapped paragraphs arrive broken at a width that matches nobody's viewport, and changing one word reflows every following line in the diff. List items, table rows and headings stay one per line, as they already are. None of this applies to code or to comments inside code, which follow the WordPress standards above.
+
+`LICENSE` and `fonts/OFL.txt` are the exception, and are not covered by any of this. They are verbatim licence texts, wrapped at the width the licensor published them at, and they stay byte-identical: do not reflow them, do not convert them to Markdown, do not rename them. Reformatting a licence is a change to a legal document rather than a formatting cleanup, and GitHub recognises `LICENSE` by that exact filename for the repository sidebar.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,5 @@
 # Abdeljalil Theme — agent guide
 
-The rulebook for this repo is [`AGENTS.md`](AGENTS.md), imported below so it loads on every session.
-Nothing in it is Claude-specific. Copilot reads a short pointer at
-[`.github/copilot-instructions.md`](.github/copilot-instructions.md), because Copilot Chat does not
-read `AGENTS.md` in every IDE.
+The rulebook for this repo is [`AGENTS.md`](AGENTS.md), imported below so it loads on every session. Nothing in it is Claude-specific. Copilot reads a short pointer at [`.github/copilot-instructions.md`](.github/copilot-instructions.md), because Copilot Chat does not read `AGENTS.md` in every IDE.
 
 @AGENTS.md


### PR DESCRIPTION
Closes #38

## What this changes

A whitespace pass over the tracked Markdown, joining every hard-wrapped prose paragraph onto one line, so `AGENTS.md`'s soft-wrap rule and the repo finally agree. Three files had anything to reflow — `AGENTS.md`, `.github/copilot-instructions.md` and `CLAUDE.md`.

The other three needed nothing, which is worth saying because the issue predicted otherwise. Its counts were lines between 60 and 101 characters, offered as a rough proxy; read line by line, every one it flagged in `README.md` (52), `.github/PULL_REQUEST_TEMPLATE.md` (2) and `fonts/README.md` (2) is already correct — a shields.io badge, a list item, a bold sub-heading under a `###`, a complete short paragraph, an indented shell command, or the GPL notice inside a fenced block. `README.md` in particular was already one line per paragraph and one line per list item throughout. Those files are untouched.

`LICENSE` and `fonts/OFL.txt` are untouched too, and the last paragraph of `AGENTS.md` now says why. That is the one wording change in the PR: the rule used to close with "Most of the Markdown here, this file included, predates the rule and is still wrapped at 100. Do not add more, and reflow what you touch," which stops being true the moment this lands. In its place is the carve-out the issue asked for — those two files are verbatim licence texts, wrapped at the width their licensor published them at, and reformatting one is a change to a legal document rather than a formatting cleanup.

## Why this way

A wrapped list item is joined into one line, not left as several. The rule says list items stay one per line, which is about not merging separate items into a paragraph — a single item spilling across three physical lines is still one item, and line 20 of `.github/copilot-instructions.md` was already written that way under the rule, so it is the shape to match.

Not scripted. A regex that joins consecutive non-blank lines cannot tell a wrapped paragraph from a badge block, from the `-->` closing an HTML comment, from the two-space hard break that `.editorconfig` explicitly preserves for Markdown. Reading each file was faster than writing a script careful enough to trust, and the verification below is the part worth automating instead.

## How to test

There is nothing to see on the site — no PHP, CSS or theme file changes, so no page renders differently.

1. Open `AGENTS.md`, `CLAUDE.md` and `.github/copilot-instructions.md` on GitHub in the Files view. They should read exactly as they did before: same paragraphs, same lists, same links, same headings.
2. Compare against the same three files on `main` side by side. The only visible difference anywhere should be the final paragraph of `AGENTS.md`, which now ends with the `LICENSE` / `fonts/OFL.txt` carve-out instead of the "predates the rule" admission.
3. Open `LICENSE` and `fonts/OFL.txt` and confirm GitHub still renders them as before, and that the licence still shows in the repository sidebar.

## What I ran

Two checks, both scripted, both on every tracked `.md` file.

First, a token-stream comparison: strip all whitespace from the before and after and confirm the same words come out in the same order. `CLAUDE.md` (44 tokens) and `.github/copilot-instructions.md` (250) are identical. `AGENTS.md` goes 1078 to 1125 tokens, and the first 1052 hash the same — the diff is confined to the tail of the last paragraph, which is exactly the intended swap and nothing else.

Second, the rendered output, since the issue asked for that rather than for trust in the diff. Each file was posted before and after to GitHub's own Markdown API in `markdown` mode — the CommonMark mode GitHub uses for repository files, not `gfm`, which is the comment mode and inserts a `<br>` at every hard-wrapped newline, so it reports a difference for exactly the change being made here. `README.md`, `.github/PULL_REQUEST_TEMPLATE.md` and `fonts/README.md` render byte-identical HTML, as they must, having not been edited. For the three that changed, the HTML differs only by a newline where there is now a space inside the same `<p>`; collapse runs of whitespace and `CLAUDE.md` and `.github/copilot-instructions.md` are byte-identical, and `AGENTS.md`'s 1145 rendered tokens differ only in that last paragraph.

Also confirmed: no CRLF, no trailing whitespace, a final newline on each file, and `git diff --stat` showing nothing outside the three files. `CLAUDE.md` had CRLF in the working tree while its blob was LF; it is written back as LF, so the diff is four lines out and one in rather than a whole-file rewrite.

## What was not checked

No PHP lint, no front-end pass, no editor — nothing this touches is loaded by WordPress.

The rendered-output check is GitHub's renderer only. It says nothing about how a local Markdown preview, an IDE, or whatever an agent uses to read `AGENTS.md` handles these files, though soft-wrapped paragraphs are the easier case for all of them.

## What to watch when it lands

Nothing ships to the live site; none of these files are part of the theme a user installs.

The thing to watch is other open branches. Any in-flight work touching `AGENTS.md`, `CLAUDE.md` or `.github/copilot-instructions.md` will conflict, because every paragraph in them moved. The conflicts are trivial to resolve — take the reflowed side and re-apply the wording — but they are best avoided by landing this after whatever else is already in flight for those files, rather than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
