### PR TITLE
Fix the tablet breakpoint, which had never applied, and correct the theme tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The theme has been rebuilt from the ground up to meet modern WordPress and web s
 ## 📱 Responsive Breakpoints
 
 - **Desktop**: > 1200px (full layout with sidebar)
-- **Tablet**: 600px - 1200px (adjusted sidebar width)
+- **Tablet**: 601px - 1200px (narrower sidebar, with a gutter on its outer edge)
 - **Mobile**: ≤ 600px (stacked single-column layout)
 
 ## 🔒 Security Improvements (v2.0)
@@ -100,12 +100,13 @@ The logo does **not** appear in the header, and no template renders it. It is us
 ## 🛠️ Changelog
 
 ### Unreleased
-**Fix the tablet breakpoint, which had never applied, and drop three invalid theme tags**
+**Fix the tablet breakpoint, which had never applied, and correct the theme tags**
 
-- The `@media` condition at the tablet breakpoint was `(max-width: var(--container-max-width))`. Custom properties are substituted at computed-value time and a media query is evaluated well before that, so the condition was invalid and browsers dropped the whole block. It had never applied on any browser, at any width, since the custom properties were introduced. The 1200 is now written out, with a comment saying why it cannot be read from `:root`.
-- Enabling the block revealed that neither of its two rules did what it looked like. `.site-wrapper { width: 100%; max-width: 100% }` is a no-op below 1200px -- the base rule's `width: 1200px; max-width: 100%` already resolves to the same number -- and has been removed. `.site-sidebar { width: calc(var(--sidebar-width) - 1%) }` never narrowed anything either: the base rule sets `flex: 0 0 var(--sidebar-width)`, and a flex item with a definite `flex-basis` ignores `width`. Left as written, the surviving `margin-inline-end: 1%` would have pushed the row to 101% and been clipped by `overflow-x: hidden`. It is now `flex-basis: calc(var(--sidebar-width) - 1%)`, which is what the rule was reaching for: 69 + 2 + 28 + 1 = 100%.
-- The visible effect between 601px and 1199px is a 1% gutter on the outer edge of the sidebar -- the left of the screen in RTL -- where the wrapper is flush to the viewport instead of centred in it. Above 1200px and at or below 600px nothing changes.
-- Dropped `right-to-left`, `arabic` and `responsive-layout` from the `Tags:` header. None is on the theme directory's allowed list: `responsive-layout` was removed when the list was revamped, and the other two were never official tags -- `rtl-language-support`, which the theme already lists, is the real one for RTL, and languages are not expressed as tags at all. The remaining seven are valid. Nothing about the theme changes; unrecognised tags only matter at .org review.
+- The `@media` condition at the tablet breakpoint was `(max-width: var(--container-max-width))`. Custom properties are substituted at computed-value time and a media query is evaluated well before that, so the condition was invalid and browsers dropped the whole block. It had never applied on any browser, at any width, since the custom properties were introduced. The 1200 is now written out, and the comment above it in `style.css` says why it cannot be read from `:root`.
+- Enabling the block revealed that neither rule inside it did what it looked like: one was a no-op and has been removed, and the sidebar's `width` never applied at all, which would have left the row overflowing by 1% once the query started matching. The sidebar now sets `flex-basis`, which is what the rule was reaching for. The comment on that rule carries the reasoning; it is the one place to change if the numbers ever move.
+- The visible effect between 601px and 1200px is a 1% gutter on the outer edge of the sidebar -- the left of the screen in RTL -- where the wrapper is flush to the viewport instead of centred in it. From 1201px up, and at or below 600px, nothing changes.
+- Dropped `right-to-left`, `arabic` and `responsive-layout` from the `Tags:` header. None is on the theme directory's allowed list: `responsive-layout` was removed when the list was revamped, and the other two were never official tags -- `rtl-language-support`, which the theme already lists, is the real one for RTL, and languages are not expressed as tags at all.
+- Also dropped `accessibility-ready`, which is a valid tag the theme does not currently earn. It carries a specific set of requirements, and the M4 issues exist precisely because those are not met yet; claiming it is a stronger statement than the other tags make. It should go back the moment that work lands. The six that remain are both valid and true. Nothing about the theme changes either way; tags only matter at .org review.
 - Theme version 2.3 to 2.4. `style.css` changed, so a cache still holding 2.3 would keep serving a stylesheet whose tablet breakpoint does nothing.
 
 **Ship the fonts as subsetted, preloaded WOFF2**

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Abdeljalil Theme v2.3
+# Abdeljalil Theme v2.4
 
 A modernized Arabic RTL WordPress theme with responsive design, HTML5 semantics, and enhanced security.
 
-![Version](https://img.shields.io/badge/version-2.3-blue.svg)
+![Version](https://img.shields.io/badge/version-2.4-blue.svg)
 ![WordPress](https://img.shields.io/badge/WordPress-5.7%2B-21759b.svg)
 ![PHP](https://img.shields.io/badge/PHP-7.4%2B-777bb4.svg)
 ![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)
@@ -100,6 +100,14 @@ The logo does **not** appear in the header, and no template renders it. It is us
 ## 🛠️ Changelog
 
 ### Unreleased
+**Fix the tablet breakpoint, which had never applied, and drop three invalid theme tags**
+
+- The `@media` condition at the tablet breakpoint was `(max-width: var(--container-max-width))`. Custom properties are substituted at computed-value time and a media query is evaluated well before that, so the condition was invalid and browsers dropped the whole block. It had never applied on any browser, at any width, since the custom properties were introduced. The 1200 is now written out, with a comment saying why it cannot be read from `:root`.
+- Enabling the block revealed that neither of its two rules did what it looked like. `.site-wrapper { width: 100%; max-width: 100% }` is a no-op below 1200px -- the base rule's `width: 1200px; max-width: 100%` already resolves to the same number -- and has been removed. `.site-sidebar { width: calc(var(--sidebar-width) - 1%) }` never narrowed anything either: the base rule sets `flex: 0 0 var(--sidebar-width)`, and a flex item with a definite `flex-basis` ignores `width`. Left as written, the surviving `margin-inline-end: 1%` would have pushed the row to 101% and been clipped by `overflow-x: hidden`. It is now `flex-basis: calc(var(--sidebar-width) - 1%)`, which is what the rule was reaching for: 69 + 2 + 28 + 1 = 100%.
+- The visible effect between 601px and 1199px is a 1% gutter on the outer edge of the sidebar -- the left of the screen in RTL -- where the wrapper is flush to the viewport instead of centred in it. Above 1200px and at or below 600px nothing changes.
+- Dropped `right-to-left`, `arabic` and `responsive-layout` from the `Tags:` header. None is on the theme directory's allowed list: `responsive-layout` was removed when the list was revamped, and the other two were never official tags -- `rtl-language-support`, which the theme already lists, is the real one for RTL, and languages are not expressed as tags at all. The remaining seven are valid. Nothing about the theme changes; unrecognised tags only matter at .org review.
+- Theme version 2.3 to 2.4. `style.css` changed, so a cache still holding 2.3 would keep serving a stylesheet whose tablet breakpoint does nothing.
+
 **Ship the fonts as subsetted, preloaded WOFF2**
 
 - The two TrueType files were 357,068 bytes, fetched on every first visit before Arabic could render in the intended face. They are replaced by two WOFF2 files totalling 110,988 bytes, a 69% reduction. Nothing was removed to get there: every glyph, codepoint and OpenType feature of the original survives, and only the container changed. The TrueType files are gone rather than kept as a fallback, because every browser that understands the logical properties and custom properties this stylesheet is built on has supported WOFF2 for years.

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * Requirements are declared once, in the style.css theme header.
  *
  * @package Abdeljalil
- * @version 2.3
+ * @version 2.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -420,7 +420,7 @@ add_action( 'widgets_init', 'abdeljalil_widgets_init' );
  **************************************************************/
 function abdeljalil_scripts() {
 	// Enqueue main stylesheet
-	wp_enqueue_style( 'abdeljalil-style', get_stylesheet_uri(), array(), '2.3' );
+	wp_enqueue_style( 'abdeljalil-style', get_stylesheet_uri(), array(), '2.4' );
 
 	// Enqueue comment reply script
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {

--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@ Author URI: https://almothafar.com
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: abdeljalil
-Tags: rtl-language-support, blog, custom-header, custom-background, threaded-comments, translation-ready, accessibility-ready
+Tags: rtl-language-support, blog, custom-header, custom-background, threaded-comments, translation-ready
 
 Original Theme: Abdeljalil Theme (2016)
 Modernized & Maintained by: Al-Mothafar Al-Hasan (https://almothafar.com)
@@ -1624,8 +1624,10 @@ video {
 		   inline-end is the left of the screen. flex-basis rather than
 		   width: the base rule sets flex: 0 0 var(--sidebar-width), and a
 		   flex item with a definite flex-basis ignores width, so the
-		   narrowing this block was written to do never happened. 28% + 1%
-		   keeps the row at 69 + 2 + 28 + 1 = 100% and out of overflow. */
+		   narrowing this block was written to do never happened. What the
+		   margin takes off the column it gives back as the gutter, so the
+		   row still totals 100%: --content-width, the wrapper's 2% gap,
+		   (--sidebar-width - 1%), and the 1% margin. */
 		flex-basis: calc(var(--sidebar-width) - 1%);
 		margin-inline-end: 1%;
 	}

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Abdeljalil Theme
 Theme URI: https://github.com/almothafar/abdeljalil-theme
 Description: A modernized Arabic RTL WordPress theme with responsive design, HTML5 semantics, and enhanced security. Originally created by Abdeljalil, now maintained and modernized by Al-Mothafar Al-Hasan.
-Version: 2.3
+Version: 2.4
 Requires at least: 5.7
 Tested up to: 6.8
 Requires PHP: 7.4
@@ -11,7 +11,7 @@ Author URI: https://almothafar.com
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: abdeljalil
-Tags: rtl-language-support, right-to-left, arabic, blog, custom-header, custom-background, threaded-comments, translation-ready, responsive-layout, accessibility-ready
+Tags: rtl-language-support, blog, custom-header, custom-background, threaded-comments, translation-ready, accessibility-ready
 
 Original Theme: Abdeljalil Theme (2016)
 Modernized & Maintained by: Al-Mothafar Al-Hasan (https://almothafar.com)
@@ -1609,16 +1609,25 @@ video {
 	height: auto;
 }
 
-/* Tablets and smaller (max-width: --container-max-width) */
-@media (max-width: var(--container-max-width)) {
-	.site-wrapper {
-		width: 100%;
-		max-width: 100%;
-	}
+/* Tablets and smaller.
 
+   The 1200 is written out rather than read from --container-max-width, and
+   has to be. A media query condition is evaluated before custom properties
+   are substituted, so var() here is not a value the browser resolves later:
+   the condition is invalid and it drops the whole block. That is why none of
+   this had ever applied. Keep the number in step with --container-max-width
+   in :root by hand. */
+@media (max-width: 1200px) {
 	.site-sidebar {
+		/* Below 1200 the wrapper is flush to the viewport instead of
+		   centred in it, so inset the sidebar's outer edge -- in RTL,
+		   inline-end is the left of the screen. flex-basis rather than
+		   width: the base rule sets flex: 0 0 var(--sidebar-width), and a
+		   flex item with a definite flex-basis ignores width, so the
+		   narrowing this block was written to do never happened. 28% + 1%
+		   keeps the row at 69 + 2 + 28 + 1 = 100% and out of overflow. */
+		flex-basis: calc(var(--sidebar-width) - 1%);
 		margin-inline-end: 1%;
-		width: calc(var(--sidebar-width) - 1%);
 	}
 }
 


### PR DESCRIPTION
Closes #33
Closes #35

## What this changes

The tablet breakpoint's condition was `@media (max-width: var(--container-max-width))`. Custom properties are substituted at computed-value time and a media query is evaluated long before that, so the condition was invalid and every browser dropped the block whole. It had never applied, at any width, since the custom properties were introduced. The `1200` is now written out, with a comment saying why it cannot be read from `:root` — that comment is the point, since the obvious tidy-up is to put the `var()` back.

Making the query valid was the easy half. The harder half, which #33 correctly called the real work, is that neither rule inside the block did what it looked like:

- `.site-wrapper { width: 100%; max-width: 100% }` is a no-op below 1200px. The base rule is `width: 1200px; max-width: 100%`, and `.site-wrapper` is a direct child of a zero-margin `body`, so both forms resolve to the same containing-block width. Removed.
- `.site-sidebar { width: calc(var(--sidebar-width) - 1%) }` never narrowed anything. The base rule sets `flex: 0 0 var(--sidebar-width)`, and a flex item with a definite `flex-basis` ignores `width`. So only `margin-inline-end: 1%` would have survived, taking the row to 69 + 2 + 29 + 1 = 101% and straight into the `overflow-x: hidden` on the wrapper. It is now `flex-basis: calc(var(--sidebar-width) - 1%)`, which is what the rule was reaching for: 28% + 1% margin = 100%.

Between 601px and 1200px the visible effect is a 1% gutter on the outer edge of the sidebar — the left of the screen in RTL — where the wrapper is flush to the viewport rather than centred in it. Above 1200 and at or below 600, nothing moves.

Also drops `right-to-left`, `arabic` and `responsive-layout` from the `Tags:` header (#35). None is on the directory's allowed list: `responsive-layout` was removed when the list was revamped, and the other two were never official — `rtl-language-support`, already listed, is the real RTL tag, and languages are not tags at all.

`accessibility-ready` is dropped too, for a different reason: it is a perfectly valid tag that this theme does not currently earn. It carries a specific set of requirements, and the M4 issues (#14, #15) exist precisely because those are not met, so listing it claimed more than any of the other tags did. It should go back the moment that work lands. The six that remain are both valid and true.

## Why this way

**#35 is batched here rather than sent on its own**, which is what its own text recommends: it touches only the `style.css` header, and a header-only change is a poor use of a version bump when another `style.css` change is going out anyway. One bump, 2.3 to 2.4, covers both.

**The fix #33 prescribed was built and measured, and it regresses.** Swapping `var()` for `1200px` and leaving the block alone produces 6px of clipped overflow at a 601px viewport, 9px at 916, and 12px at 1200 — the article column's right edge cut off, and the sidebar with no left gutter at all, the exact opposite of the rule's intent. It is invisible only because `overflow-x: hidden` is hiding it. That is why the block is adjusted rather than simply switched on. The issue anticipated this ("they may need adjusting rather than simply enabling"); this is what the adjustment turned out to be.

**The block is repaired rather than deleted.** Deleting it would have been the zero-risk option, since it has never run and the desktop percentages already reflow fluidly below 1200px. But the outer-edge gutter is a real design decision the original author made and could never see take effect, and #33 asks for a working tablet breakpoint, not for the absence of one.

## What to look at

The surviving rule is expressed against `--sidebar-width`, so if the 29% ever changes, the narrowing follows it. The 1200 in the media query is the one number that has to be kept in step by hand, which is what the comment is for.

`accessibility-ready` coming out is the one judgement call here that is not forced by the code. It is reversible in one word, and it is the thing to push back on if you would rather keep the claim standing while #14 and #15 are in flight.

## How to test

1. Open a post on a browser window between 601px and 1200px wide. The sidebar should sit about 1% clear of the left edge of the window rather than flush against it; the article column is unchanged.
2. Widen past 1200px. The layout should return to the centred 1200px container with the sidebar flush to the container edge, exactly as it renders today.
3. Narrow below 600px. The single-column stack should be unchanged.
4. At every width in between, check nothing is clipped horizontally: no content should disappear under the right edge. `overflow-x: hidden` on `.site-wrapper` will hide an overflow rather than show a scrollbar, so read the column edges rather than looking for one.
5. Hard-refresh, or check the stylesheet request carries `?ver=2.4`. The old file is `?ver=2.3` and a cache holding it will show none of this.
6. `Appearance → Themes` still lists the theme normally after the `Tags:` change, and home, a category archive, a search result, a page and a 404 all render with `WP_DEBUG` on.

## What the review changed

A two-axis review of this branch found no missing requirement and no wrong implementation, and four things worth acting on. All four are in the second commit, which changes no declaration:

- `accessibility-ready` dropped, as above. The review's sharpest point was that the first version deferred this rather than deciding it, which would have closed #35 with its central question open.
- The CSS comment gave the sum as `69 + 2 + 28 + 1 = 100%`. Neither 69 nor 28 appears anywhere in the code — the first is `--content-width`, the second is `--sidebar-width` less the margin — so a reader checking the arithmetic against `:root` met a number that did not match. It is now written against the custom properties themselves.
- The changelog restated the whole mechanism the CSS comment already carries, down to that same sum, leaving one paragraph in three places to drift apart. It now gives the outcome and points at the comment as the single source.
- The changelog put the end of the tablet range at 1199px. `max-width: 1200px` is inclusive, so it is 1200. The `Responsive Breakpoints` section had the same off-by-one at the other end, listing tablet as starting at 600px when 600 is mobile; corrected as well, since that section now describes a breakpoint that actually applies.

The headless-Chrome measurements at 600, 601, 900, 1200 and 1201 return byte-identical readings before and after that commit, which is what confirms it is comment-and-prose only.

## What I ran

`php -l` over all 17 `.php` files on 7.4.33 and 8.5.10, clean on both. The only PHP change is the version string in the enqueue and the docblock.

Then, since Chrome turned out to be on the machine, this was measured rather than reasoned. I built three standalone pages carrying the theme's markup skeleton, each inlining a complete real `style.css` — `main`, the naive fix, and this branch — and ran them through headless Chrome at ten viewport widths, reading back the computed `flex-basis`, the computed `margin-left`, the measured column widths, and `scrollWidth - clientWidth` on the wrapper.

| viewport | main | naive fix | this branch |
| --- | --- | --- | --- |
| 600 (mobile) | basis 100%, no overflow | basis 100%, no overflow | basis 100%, no overflow |
| 601 | basis 29%, margin 0 | basis 29%, margin 5.9px, **6px clipped** | basis 28%, margin 5.9px, no overflow |
| 900 | basis 29%, margin 0 | basis 29%, margin 8.7px, **9px clipped** | basis 28%, margin 8.7px, no overflow |
| 1200 | basis 29%, margin 0 | basis 29%, margin 11.8px, **12px clipped** | basis 28%, margin 11.8px, no overflow |
| 1201 (desktop) | basis 29%, margin 0 | basis 29%, margin 0 | basis 29%, margin 0 |

The `main` column is the bug: `margin-left: 0px` and `flex-basis: 29%` right across the tablet range, meaning the block never applied, which is what #33 claimed and what this confirms independently. The desktop and mobile rows are identical across all three, which is the regression check. Screenshots at 916px confirm the same thing visually.

## What was not checked

Not run inside WordPress. The harness pages carry hand-written markup matching the templates' class structure, not markup WordPress generated, so widget output, comment threads, embeds and images at tablet widths are unverified — the columns they sit in are measured, their contents are not.

The 1% gutter is now real for the first time. Whether 1% is the right amount is a design judgement I cannot make from measurements, and nobody has ever seen this breakpoint in use to have an opinion yet. If it looks wrong in practice, the number is in one place.

Only Chrome. Flexbox `flex-basis` versus `width` precedence is specified behaviour rather than a browser quirk, so Firefox and Safari should agree, but I did not confirm it.

`Tested up to:` is left at 6.8; nothing here was verified against a newer WordPress.

## What to watch when it lands

`style.css` and `functions.php` must be copied together — they carry the version, 2.4, and if they disagree browsers keep serving the 2.3 stylesheet and none of this appears. `README.md` moves with them for the changelog and badge, but only `style.css` and `functions.php` matter to the running site.

Existing posts and settings are untouched; this is layout CSS only, with no stored state.

One thing the diff cannot show: the version lives in **three** places, not the two `AGENTS.md` names. Alongside the `style.css` header and the `wp_enqueue_style()` argument, `functions.php`'s docblock carries `@version`, and it has in fact moved with every release since 2.0. All three are at 2.4 here. `AGENTS.md`'s "The version lives in two places" is worth correcting, but that is a docs change and did not belong in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
